### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ OpenHMD is released under the permissive Boost Software License (see LICENSE for
 ## Supported Platforms
   * Linux
   * Windows
-  * Mac Os X
+  * OS X
 
 ## Requirements
   * HIDAPI


### PR DESCRIPTION
It's "OS X" (since 10.8) not "Mac Os X" :-)
Same issue is on the website btw.
