### PR TITLE
Fixed OHMD_LEFT_EYE_ASPECT_RATIO bug in ohmd_device_getf

### DIFF
--- a/src/openhmd.c
+++ b/src/openhmd.c
@@ -149,7 +149,7 @@ OHMD_APIENTRY int ohmd_device_getf(ohmd_device* device, ohmd_float_value type, f
 		return 0;
 	case OHMD_RIGHT_EYE_ASPECT_RATIO:
 	case OHMD_LEFT_EYE_ASPECT_RATIO:
-		*out = device->properties.fov;
+		*out = device->properties.ratio;
 		return 0;
 
 	case OHMD_EYE_IPD:


### PR DESCRIPTION
Hi!
I fixed a small copy past bug in openhmd.c

ohmd_device_getf for OHMD_RIGHT_EYE_ASPECT_RATIO and OHMD_LEFT_EYE_ASPECT_RATIO returned the wrong value.
