### PR TITLE
Fixes for compilation with MSVC

### DIFF
--- a/include/openhmd.h
+++ b/include/openhmd.h
@@ -18,16 +18,20 @@ extern "C" {
 
 #ifdef _WIN32
 #ifdef DLL_EXPORT
-#define OHMD_APIENTRY __cdecl __declspec( dllexport )
+#define OHMD_APIENTRY __cdecl 
+#define OHMD_APIENTRYDLL __declspec( dllexport )
 #else
 #ifdef OHMD_STATIC
 #define OHMD_APIENTRY __cdecl
+#define OHMD_APIENTRYDLL
 #else
-#define OHMD_APIENTRY __cdecl __declspec( dllimport )
+#define OHMD_APIENTRY __cdecl
+#define OHMD_APIENTRYDLL __declspec( dllimport )
 #endif
 #endif
 #else
 #define OHMD_APIENTRY
+#define OHMD_APIENTRYDLL
 #endif
 
 /** Maximum length of a string, including termination, in OpenHMD. */
@@ -121,7 +125,7 @@ typedef struct ohmd_device ohmd_device;
  *
  * @return a pointer to an allocated ohmd_context on success or NULL if it fails
  */
-OHMD_APIENTRY ohmd_context* ohmd_ctx_create();
+OHMD_APIENTRYDLL ohmd_context* OHMD_APIENTRY ohmd_ctx_create();
 
 /**
  * Destroy an OpenHMD context. 
@@ -130,7 +134,7 @@ OHMD_APIENTRY ohmd_context* ohmd_ctx_create();
  *  
  * @param ctx The context to destroy.
  */
-OHMD_APIENTRY void ohmd_ctx_destroy(ohmd_context* ctx);
+OHMD_APIENTRYDLL void OHMD_APIENTRY ohmd_ctx_destroy(ohmd_context* ctx);
 
 /**
  * Get the last error as a human readable string. 
@@ -141,7 +145,7 @@ OHMD_APIENTRY void ohmd_ctx_destroy(ohmd_context* ctx);
  * @param ctx The context to retreive the error message from.
  * @return a pointer to the error message
  */
-OHMD_APIENTRY const char* ohmd_ctx_get_error(ohmd_context* ctx);
+OHMD_APIENTRYDLL const char* OHMD_APIENTRY ohmd_ctx_get_error(ohmd_context* ctx);
 
 /**
  * Update a context.
@@ -154,7 +158,7 @@ OHMD_APIENTRY const char* ohmd_ctx_get_error(ohmd_context* ctx);
  * 
  * @param ctx The context that needs updating.
  */
-OHMD_APIENTRY void ohmd_ctx_update(ohmd_context* ctx);
+OHMD_APIENTRYDLL void OHMD_APIENTRY ohmd_ctx_update(ohmd_context* ctx);
 
 /**
  * Probe for devices.
@@ -164,7 +168,7 @@ OHMD_APIENTRY void ohmd_ctx_update(ohmd_context* ctx);
  * @param ctx A context with no currently open devices.
  * @return number of devices found on the system
  */
-OHMD_APIENTRY int ohmd_ctx_probe(ohmd_context* ctx);
+OHMD_APIENTRYDLL int OHMD_APIENTRY ohmd_ctx_probe(ohmd_context* ctx);
 
 /**
  * Get device description from enumeration list index.
@@ -181,7 +185,7 @@ OHMD_APIENTRY int ohmd_ctx_probe(ohmd_context* ctx);
  * @param type The type of data to fetch. One of OHMD_VENDOR, OHMD_PRODUCT and OHMD_PATH.
  * @return a string with a human readable device name
  */
-OHMD_APIENTRY const char* ohmd_list_gets(ohmd_context* ctx, int index, ohmd_string_value type);
+OHMD_APIENTRYDLL const char* OHMD_APIENTRY ohmd_list_gets(ohmd_context* ctx, int index, ohmd_string_value type);
 
 /**
  * Open a device.
@@ -195,7 +199,7 @@ OHMD_APIENTRY const char* ohmd_list_gets(ohmd_context* ctx, int index, ohmd_stri
  * @param index An index, between 0 and the value returned from ohmd_ctx_probe.
  * @return a pointer to an ohmd_device, which represents a hardware device, such as an HMD.
  */
-OHMD_APIENTRY ohmd_device* ohmd_list_open_device(ohmd_context* ctx, int index);
+OHMD_APIENTRYDLL ohmd_device* OHMD_APIENTRY ohmd_list_open_device(ohmd_context* ctx, int index);
 
 /**
  * Get a floating point value from a device.
@@ -206,7 +210,7 @@ OHMD_APIENTRY ohmd_device* ohmd_list_open_device(ohmd_context* ctx, int index);
  * @param[out] out A pointer to a float, or float array where the retreived value should be written.
  * @return 0 on success, <0 on failure.
  */
-OHMD_APIENTRY int ohmd_device_getf(ohmd_device* device, ohmd_float_value type, float* out);
+OHMD_APIENTRYDLL int OHMD_APIENTRY ohmd_device_getf(ohmd_device* device, ohmd_float_value type, float* out);
 
 /**
  * Set a floating point value for a device.
@@ -216,7 +220,7 @@ OHMD_APIENTRY int ohmd_device_getf(ohmd_device* device, ohmd_float_value type, f
  * @param in A pointer to a float, or float array where the new value is stored.
  * @return 0 on success, <0 on failure.
  */
-OHMD_APIENTRY int ohmd_device_setf(ohmd_device* device, ohmd_float_value type, float* in);
+OHMD_APIENTRYDLL int OHMD_APIENTRY ohmd_device_setf(ohmd_device* device, ohmd_float_value type, float* in);
 
 /**
  * Get an integer value from a device. 
@@ -226,7 +230,7 @@ OHMD_APIENTRY int ohmd_device_setf(ohmd_device* device, ohmd_float_value type, f
  * @param[out] out A pointer to an integer, or integer array where the retreived value should be written.
  * @return 0 on success, <0 on failure.
  */
-OHMD_APIENTRY int ohmd_device_geti(ohmd_device* device, ohmd_int_value type, int* out);
+OHMD_APIENTRYDLL int OHMD_APIENTRY ohmd_device_geti(ohmd_device* device, ohmd_int_value type, int* out);
 
 #ifdef __cplusplus
 }

--- a/src/log.h
+++ b/src/log.h
@@ -30,6 +30,10 @@ void* ohmd_allocfn(ohmd_context* ctx, char* e_msg, size_t size);
 #define LOGW(...) LOG(3, "WW", __VA_ARGS__)
 #define LOGE(...) LOG(4, "EE", __VA_ARGS__)
 
+#ifdef _MSC_VER
+#define snprintf _snprintf
+#endif
+
 #define ohmd_set_error(_ctx, ...) { snprintf((_ctx)->error_msg, OHMD_STR_SIZE, __VA_ARGS__); LOGE(__VA_ARGS__); }
 
 #endif

--- a/src/openhmd.c
+++ b/src/openhmd.c
@@ -10,8 +10,10 @@
 #include "openhmdi.h"
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
-OHMD_APIENTRY ohmd_context* ohmd_ctx_create()
+
+ohmd_context* OHMD_APIENTRY ohmd_ctx_create()
 {
 	ohmd_context* ctx = calloc(1, sizeof(ohmd_context));
 	if(!ctx){
@@ -27,7 +29,7 @@ OHMD_APIENTRY ohmd_context* ohmd_ctx_create()
 	return ctx;
 }
 
-OHMD_APIENTRY void ohmd_ctx_destroy(ohmd_context* ctx)
+void OHMD_APIENTRY ohmd_ctx_destroy(ohmd_context* ctx)
 {
 	for(int i = 0; i < ctx->num_active_devices; i++){
 		ctx->active_devices[i]->close(ctx->active_devices[i]);
@@ -40,18 +42,18 @@ OHMD_APIENTRY void ohmd_ctx_destroy(ohmd_context* ctx)
 	free(ctx);
 }
 
-OHMD_APIENTRY void ohmd_ctx_update(ohmd_context* ctx)
+void OHMD_APIENTRY ohmd_ctx_update(ohmd_context* ctx)
 {
 	for(int i = 0; i < ctx->num_active_devices; i++)
 		ctx->active_devices[i]->update(ctx->active_devices[i]);
 }
 
-OHMD_APIENTRY const char* ohmd_ctx_get_error(ohmd_context* ctx)
+const char* OHMD_APIENTRY ohmd_ctx_get_error(ohmd_context* ctx)
 {
 	return ctx->error_msg;
 }
 
-OHMD_APIENTRY int ohmd_ctx_probe(ohmd_context* ctx)
+int OHMD_APIENTRY ohmd_ctx_probe(ohmd_context* ctx)
 {
 	memset(&ctx->list, 0, sizeof(ohmd_device_list));
 	for(int i = 0; i < ctx->num_drivers; i++){
@@ -61,7 +63,7 @@ OHMD_APIENTRY int ohmd_ctx_probe(ohmd_context* ctx)
 	return ctx->list.num_devices;
 }
 
-OHMD_APIENTRY const char* ohmd_list_gets(ohmd_context* ctx, int index, ohmd_string_value type)
+const char* OHMD_APIENTRY ohmd_list_gets(ohmd_context* ctx, int index, ohmd_string_value type)
 {
 	if(index >= ctx->list.num_devices)
 		return NULL;
@@ -78,7 +80,7 @@ OHMD_APIENTRY const char* ohmd_list_gets(ohmd_context* ctx, int index, ohmd_stri
 	}
 }
 
-OHMD_APIENTRY ohmd_device* ohmd_list_open_device(ohmd_context* ctx, int index)
+ohmd_device* OHMD_APIENTRY ohmd_list_open_device(ohmd_context* ctx, int index)
 {
 	if(index >= 0 && index < ctx->list.num_devices){
 
@@ -97,7 +99,7 @@ OHMD_APIENTRY ohmd_device* ohmd_list_open_device(ohmd_context* ctx, int index)
 	return NULL;
 }
 
-OHMD_APIENTRY int ohmd_device_getf(ohmd_device* device, ohmd_float_value type, float* out)
+int OHMD_APIENTRY ohmd_device_getf(ohmd_device* device, ohmd_float_value type, float* out)
 {
 	switch(type){
 	case OHMD_LEFT_EYE_GL_MODELVIEW_MATRIX: {
@@ -167,7 +169,7 @@ OHMD_APIENTRY int ohmd_device_getf(ohmd_device* device, ohmd_float_value type, f
 	}
 }
 
-OHMD_APIENTRY int ohmd_device_setf(ohmd_device* device, ohmd_float_value type, float* in)
+int OHMD_APIENTRY ohmd_device_setf(ohmd_device* device, ohmd_float_value type, float* in)
 {
 	switch(type){
 	case OHMD_EYE_IPD:
@@ -184,7 +186,7 @@ OHMD_APIENTRY int ohmd_device_setf(ohmd_device* device, ohmd_float_value type, f
 	}
 }
 
-OHMD_APIENTRY int ohmd_device_geti(ohmd_device* device, ohmd_int_value type, int* out)
+int OHMD_APIENTRY ohmd_device_geti(ohmd_device* device, ohmd_int_value type, int* out)
 {
 	switch(type){
 	case OHMD_SCREEN_HORIZONTAL_RESOLUTION:


### PR DESCRIPTION
I fixed some Visual Studio compilation problems (if mingw is not a practical option).
There were some DLL keyword placement issues.

I just thought you might want to pull it.
