### PR TITLE
Moved the device pointer check to before any dereference is attempted.

### DIFF
--- a/src/openhmd.c
+++ b/src/openhmd.c
@@ -88,10 +88,10 @@ ohmd_device* OHMD_APIENTRY ohmd_list_open_device(ohmd_context* ctx, int index)
 		ohmd_driver* driver = (ohmd_driver*)desc->driver_ptr;
 		ohmd_device* device = driver->open_device(driver, desc);
 
-		device->rotation_correction.w = 1;
-
 		if (device == NULL)
 			return NULL;
+
+		device->rotation_correction.w = 1;
 
 		device->ctx = ctx;
 		device->active_device_idx = ctx->num_active_devices;


### PR DESCRIPTION
The title is self explanatory. As it stands a dereference is attempted before the pointer is checked for validity.