### PR TITLE
Quiet warning when using -Wformat-signedness

### DIFF
--- a/src/drv_dummy/dummy.c
+++ b/src/drv_dummy/dummy.c
@@ -38,7 +38,7 @@ static int getf(ohmd_device* device, ohmd_float_value type, float* out)
 		break;
 
 	default:
-		ohmd_set_error(priv->base.ctx, "invalid type given to getf (%d)", type);
+		ohmd_set_error(priv->base.ctx, "invalid type given to getf (%ud)", type);
 		return -1;
 		break;
 	}

--- a/src/drv_oculus_rift/rift.c
+++ b/src/drv_oculus_rift/rift.c
@@ -169,7 +169,7 @@ static int getf(ohmd_device* device, ohmd_float_value type, float* out)
 		break;
 
 	default:
-		ohmd_set_error(priv->base.ctx, "invalid type given to getf (%d)", type);
+		ohmd_set_error(priv->base.ctx, "invalid type given to getf (%ud)", type);
 		return -1;
 		break;
 	}


### PR DESCRIPTION
We get warnings here when building OpenHMD with Blender, which is a bit annoying, so would be good to have it fixed in upstream. Forcing a signed enum would also work, but that would mean adding an unused value.