### PR TITLE
FIx some Oculus DK2 problems.

### DIFF
--- a/src/drv_oculus_rift/rift.c
+++ b/src/drv_oculus_rift/rift.c
@@ -196,8 +196,10 @@ static ohmd_device* open_device(ohmd_driver* driver, ohmd_device_desc* desc)
 	// Open the HID device
 	priv->handle = hid_open_path(desc->path);
 
-	if(!priv->handle)
+	if(!priv->handle) {
+    ohmd_set_error(driver->ctx, "Could not open HID device path %s. Check your rights.", desc->path);
 		goto cleanup;
+	}
 	
 	if(hid_set_nonblocking(priv->handle, 1) == -1){
 		ohmd_set_error(driver->ctx, "failed to set non-blocking on device");

--- a/src/openhmd.c
+++ b/src/openhmd.c
@@ -158,10 +158,11 @@ ohmd_device* OHMD_APIENTRY ohmd_list_open_device_s(ohmd_context* ctx, int index,
 		device->active_device_idx = ctx->num_active_devices;
 		ctx->active_devices[ctx->num_active_devices++] = device;
 
+		ohmd_unlock_mutex(ctx->update_mutex);
+
 		if(device->settings.automatic_update)
 			ohmd_set_up_update_thread(ctx);
 
-		ohmd_unlock_mutex(ctx->update_mutex);
 		return device;
 	}
 


### PR DESCRIPTION
When running OpenHMD in gdb I noticed a race segfault due to a locked mutex.
ohmd_set_up_update_thread actually recreates the mutex, it should be unlocked before that. The patch works fine for me.

Furthermore OpenHMD wasn't very verbose about which HID device path failed to open and what the reason for this may be. The second patch adds this error message, before that the error in the context was empty when the device failed to open.