### PR TITLE
Fix some Oculus DK2 problems. Rev 2.

### DIFF
--- a/src/openhmd.c
+++ b/src/openhmd.c
@@ -158,10 +158,11 @@ ohmd_device* OHMD_APIENTRY ohmd_list_open_device_s(ohmd_context* ctx, int index,
 		device->active_device_idx = ctx->num_active_devices;
 		ctx->active_devices[ctx->num_active_devices++] = device;
 
+		ohmd_unlock_mutex(ctx->update_mutex);
+
 		if(device->settings.automatic_update)
 			ohmd_set_up_update_thread(ctx);
 
-		ohmd_unlock_mutex(ctx->update_mutex);
 		return device;
 	}
 


### PR DESCRIPTION
Updated patches after review in https://github.com/OpenHMD/OpenHMD/pull/58
I also made the error message print the actual unix device path, so you could run chmod to work around the rights issue if you like.