### PR TITLE
Workaround the CV1 resetting issue

### DIFF
--- a/src/drv_oculus_rift/packet.c
+++ b/src/drv_oculus_rift/packet.c
@@ -200,7 +200,7 @@ int encode_enable_components(unsigned char* buffer, bool display, bool audio)
 		flags |= 1;
 	if (audio)
 		flags |= 2;
-	flags |= 4; // I don't know what it is. Wireless?
+//	flags |= 4; // I don't know what it is. Wireless?
 	WRITE8(flags);
 	return 4;
 }

--- a/src/drv_oculus_rift/rift.c
+++ b/src/drv_oculus_rift/rift.c
@@ -141,7 +141,8 @@ static void update_device(ohmd_device* device)
 		// send keep alive message
 		pkt_keep_alive keep_alive = { 0, priv->sensor_config.keep_alive_interval };
 		int ka_size = encode_keep_alive(buffer, &keep_alive);
-		send_feature_report(priv, buffer, ka_size);
+		if (send_feature_report(priv, buffer, ka_size) == -1)
+			LOGE("error sending keepalive");
 
 		// Update the time of the last keep alive we have sent.
 		priv->last_keep_alive = t;
@@ -276,13 +277,15 @@ static ohmd_device* open_device(ohmd_driver* driver, ohmd_device_desc* desc)
 	if (desc->revision == REV_CV1)
 	{
 		size = encode_enable_components(buf, true, true);
-		send_feature_report(priv, buf, size);
+		if (send_feature_report(priv, buf, size) == -1)
+			LOGE("error turning the screens on");
 	}
 
 	// set keep alive interval to n seconds
 	pkt_keep_alive keep_alive = { 0, KEEP_ALIVE_VALUE };
 	size = encode_keep_alive(buf, &keep_alive);
-	send_feature_report(priv, buf, size);
+	if (send_feature_report(priv, buf, size) == -1)
+		LOGE("error setting up keepalive");
 
 	// Update the time of the last keep alive we have sent.
 	priv->last_keep_alive = ohmd_get_tick();


### PR DESCRIPTION
When enabling feature 4 (unknown so far, not used in any way by OpenHMD yet), the CV1 occasionally resets, leading to read errors in OpenHMD.

Not knowing the correct setup sequence to reliably enable feature 4, and not knowing what it is in the first place, disabling it makes OpenHMD reliably usable with the CV1.