### PR TITLE
OSVR HDK: Convert fixed-point values to floats.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,9 +96,8 @@ if (OPENHMD_EXAMPLE_SDL)
 	add_subdirectory(./examples/opengl)
 endif (OPENHMD_EXAMPLE_SDL)
 
-if (UNIX)
-	set(LIBS ${LIBS} rt pthread)
-endif (UNIX)
+find_package(Threads REQUIRED)
+set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
 
 link_libraries(${LIBS})
 add_library(openhmd ${openhmd_source_files})

--- a/src/drv_osvr_hdk/osvr.c
+++ b/src/drv_osvr_hdk/osvr.c
@@ -55,10 +55,17 @@ static int send_feature_report(drv_priv* priv, const unsigned char *data, size_t
 
 void quatf_from_device_quat(const int16_t* smp, quatf* out_quat)
 {
-	out_quat->x = (float)smp[0];
-	out_quat->y = (float)smp[1];
-	out_quat->z = (float)smp[2];
-	out_quat->w = (float)smp[3];
+	out_quat->x = (float)smp[0] / (1 << 14);
+	out_quat->y = (float)smp[1] / (1 << 14);
+	out_quat->z = (float)smp[2] / (1 << 14);
+	out_quat->w = (float)smp[3] / (1 << 14);
+}
+
+void vec3f_from_device_accel(const int16_t* accel, vec3f* out_vec)
+{
+	out_vec->x = (float)accel[0] / (1 << 9);
+	out_vec->y = (float)accel[1] / (1 << 9);
+	out_vec->z = (float)accel[2] / (1 << 9);
 }
 
 static void handle_tracker_sensor_msg(drv_priv* priv, unsigned char* buffer, int size)
@@ -71,6 +78,7 @@ static void handle_tracker_sensor_msg(drv_priv* priv, unsigned char* buffer, int
 
 	osvr_dump_packet_tracker_sensor(s);
 	quatf_from_device_quat(s->device_quat, &priv->processed_quat);
+	vec3f_from_device_accel(s->accel, &priv->raw_accel);
 	priv->sensor_fusion.orient = priv->processed_quat;
 }
 

--- a/src/drv_osvr_hdk/osvr.h
+++ b/src/drv_osvr_hdk/osvr.h
@@ -58,6 +58,7 @@ typedef struct {
 } pkt_keep_alive;
 
 void quatf_from_device_quat(const int16_t* smp, quatf* out_quat);
+void vec3f_from_device_accel(const int16_t* accel, vec3f* out_vec);
 
 bool osvr_decode_sensor_display_info(pkt_sensor_display_info* info, const unsigned char* buffer, int size);
 bool osvr_decode_sensor_config(pkt_sensor_config* config, const unsigned char* buffer, int size);


### PR DESCRIPTION
This PR does the following:

 * Converts 16-bit fixed-point values to floats (for both the quaternion and acceleration vector).
 * Fixes the use of a threading library in the CMake file (this makes it cross-platform). It failed to compile under OS X as it was.

Note that I haven't tested this beyond ensuring it compiles successfully.
