### PR TITLE
examples/opengl: switch to SDL2 and epoxy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,30 +86,12 @@ AM_CONDITIONAL([BUILD_OPENGL_EXAMPLE], [test "x$openglexample_enabled" != "xno"]
 
 # Libs required by OpenGL test
 AS_IF([test "x$openglexample_enabled" != "xno"], [
-	PKG_CHECK_MODULES([sdl], [sdl])
+	PKG_CHECK_MODULES([sdl2], [sdl2])
 
-	# Try to find OpenGL with pkg-config
-	PKG_CHECK_MODULES([GL], [gl], [],
-			# and try to find which lib to link to, -lGL first
-			[AC_CHECK_LIB(GL, glBegin, [GL_LIBS=-lGL],
+	PKG_CHECK_MODULES([epoxy], [epoxy])
 
-				# if that fails, try -lopengl32 (win32)
-				[AC_CHECK_LIB(opengl32, main, [GL_LIBS=-lopengl32],
-					AC_MSG_ERROR([GL not found])
-				)]
-			)]
-	)
-
-	AC_SUBST(GL_LIBS)
-
-	# Try to find GLEW with pkg-config
-	PKG_CHECK_MODULES([GLEW], [glew], [],
-		# if that fails, check if there's a glew header
-		[AC_CHECK_HEADER([GL/glew.h], [GLEW_LIBS=-lGLEW; GLEW_CFLAGS=-DGLEW_STATIC], AC_MSG_ERROR([GLEW not found]))]
-	)
-
-	AC_SUBST(GLEW_LIBS)
-	AC_SUBST(GLEW_CFLAGS)
+	AC_SUBST(epoxy_LIBS)
+	AC_SUBST(epoxy_CFLAGS)
 ])
 
 AC_PROG_CC

--- a/examples/opengl/Makefile.am
+++ b/examples/opengl/Makefile.am
@@ -1,5 +1,5 @@
 bin_PROGRAMS = openglexample
-AM_CPPFLAGS = -Wall -Werror -I$(top_srcdir)/include -DOHMD_STATIC $(sdl_CFLAGS) $(GLEW_CFLAGS)
+AM_CPPFLAGS = -Wall -Werror -I$(top_srcdir)/include -DOHMD_STATIC $(sdl2_CFLAGS) $(epoxy_CFLAGS)
 openglexample_SOURCES = gl.c main.c
 openglexample_LDADD = $(top_builddir)/src/libopenhmd.la -lm
-openglexample_LDFLAGS = -static-libtool-libs $(sdl_LIBS) $(GLEW_LIBS) $(GL_LIBS)
+openglexample_LDFLAGS = -static-libtool-libs $(sdl2_LIBS) $(epoxy_LIBS)

--- a/examples/opengl/gl.c
+++ b/examples/opengl/gl.c
@@ -31,13 +31,23 @@ void init_gl(gl_ctx* ctx, int w, int h)
 	}
 
 	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-	SDL_GL_SetAttribute(SDL_GL_SWAP_CONTROL, 1);
 
-	ctx->screen = SDL_SetVideoMode(w, h, 0, SDL_OPENGL | SDL_GL_DOUBLEBUFFER);
-	if(ctx->screen == NULL){
-		printf("SDL_SetVideoMode failed\n");
+	ctx->window = SDL_CreateWindow("OpenHMD opengl example",
+        SDL_WINDOWPOS_UNDEFINED,
+        SDL_WINDOWPOS_UNDEFINED,
+        w, h, SDL_WINDOW_FULLSCREEN_DESKTOP | SDL_WINDOW_OPENGL | SDL_GL_DOUBLEBUFFER);
+	if(ctx->window == NULL){
+		printf("SDL_CreateWindow failed\n");
 		exit(-1);
 	}
+
+    ctx->glcontext = SDL_GL_CreateContext(ctx->window);
+    if(ctx->glcontext == NULL){
+        printf("SDL_GL_CreateContext\n");
+        exit(-1);
+    }
+
+	SDL_GL_SetSwapInterval(1);
 
 	// Disable ctrl-c catching on linux (and OS X?) 
 	#ifdef __unix
@@ -45,7 +55,7 @@ void init_gl(gl_ctx* ctx, int w, int h)
 	#endif
 
 	// Load extensions.
-	glewInit();
+	//glewInit();
 
 	printf("OpenGL Renderer: %s\n", glGetString(GL_RENDERER));
 	printf("OpenGL Vendor: %s\n", glGetString(GL_VENDOR));
@@ -69,7 +79,10 @@ void init_gl(gl_ctx* ctx, int w, int h)
 	glEnable(GL_POLYGON_SMOOTH); 
 	glLoadIdentity();
 
-	glViewport(0, 0, ctx->screen->w, ctx->screen->h);
+    SDL_GetWindowSize(ctx->window, &w, &h);
+    printf("Actual window size: %dx%d\n", w, h);
+
+	glViewport(0, 0, w, h);
 }
 
 void ortho(gl_ctx* ctx)
@@ -78,7 +91,9 @@ void ortho(gl_ctx* ctx)
 	//glPushMatrix();
 	glLoadIdentity();
 
-	glOrtho(0.0f, ctx->screen->w, ctx->screen->h, 0.0f, -1.0f, 1.0f);
+    int w, h;
+    SDL_GetWindowSize(ctx->window, &w, &h);
+	glOrtho(0.0f, w, h, 0.0f, -1.0f, 1.0f);
 	glMatrixMode(GL_MODELVIEW);
 	//glPushMatrix();
 	glLoadIdentity();

--- a/examples/opengl/gl.h
+++ b/examples/opengl/gl.h
@@ -12,12 +12,18 @@
 
 #include <SDL.h>
 
-#include <GL/glew.h>
-#include <GL/gl.h>
+#include <epoxy/gl.h>
+#include <epoxy/glx.h>
+#include <epoxy/egl.h>
+
+// Check under windows - doesn't exist in fedora install, so ifdef appropriately
+//#include <epoxy/wgl.h>
 
 typedef struct {
 	int w, h;
-	SDL_Surface* screen;
+	SDL_Window* window;
+    SDL_GLContext glcontext;
+    int is_fullscreen;
 } gl_ctx;
 
 void ortho(gl_ctx* ctx);

--- a/examples/opengl/main.c
+++ b/examples/opengl/main.c
@@ -141,7 +141,8 @@ int main(int argc, char** argv)
 					done = true;
 					break;
 				case SDLK_F1:
-					SDL_WM_ToggleFullScreen(gl.screen);
+                    gl.is_fullscreen = !gl.is_fullscreen;
+					SDL_SetWindowFullscreen(gl.window, gl.is_fullscreen ? SDL_WINDOW_FULLSCREEN : 0);
 					break;
 				case SDLK_F2:
 					{
@@ -244,7 +245,7 @@ int main(int argc, char** argv)
 		glUseProgram(0);
 
 		// Da swap-dawup!
-		SDL_GL_SwapBuffers();
+		SDL_GL_SwapWindow(gl.window);
 		SDL_Delay(10);
 	}
 


### PR DESCRIPTION
Tested with DK1 on linux Fedora 25 with X11 and wayland with nouveau NVE6. No tearing in
wayland :)

I realize this is just a test app. I did not test yet on windows, but from reading the epoxy docs it should just require adding a wgl.h include, or maybe not even that.