### PR TITLE
Rift asymmetric frustum

### DIFF
--- a/src/omath.c
+++ b/src/omath.c
@@ -249,6 +249,39 @@ void omat4x4f_init_perspective(mat4x4f* me, float fovy_rad, float aspect, float 
 	me->m[3][3] = 0;
 }
 
+void omat4x4f_init_frustum(mat4x4f* me, float left, float right, float bottom, float top, float znear, float zfar)
+{
+    omat4x4f_init_ident(me);
+
+    float delta_x = right - left;
+    float delta_y = top - bottom;
+	float delta_z = zfar - znear;
+	if ((delta_x == 0.0f) || (delta_y == 0.0f) || (delta_z == 0.0f)) {
+        /* can't divide by zero, so just give back identity */
+		return;
+	}
+
+	me->m[0][0] = 2.0f * znear / delta_x;
+	me->m[0][1] = 0;
+	me->m[0][2] = (right + left) / delta_x;
+	me->m[0][3] = 0;
+
+	me->m[1][0] = 0;
+	me->m[1][1] = 2.0f * znear / delta_y;
+	me->m[1][2] = (top + bottom) / delta_y;
+	me->m[1][3] = 0;
+
+	me->m[2][0] = 0;
+	me->m[2][1] = 0;
+	me->m[2][2] = (zfar + znear) / delta_z;
+	me->m[2][3] = 2.0f * zfar * znear / delta_z;
+
+	me->m[3][0] = 0;
+	me->m[3][1] = 0;
+	me->m[3][2] = -1.0f;
+	me->m[3][3] = 0;
+}
+
 void omat4x4f_init_look_at(mat4x4f* me, const quatf* rot, const vec3f* eye)
 {
 	quatf q;

--- a/src/omath.h
+++ b/src/omath.h
@@ -67,6 +67,7 @@ typedef union {
 
 void omat4x4f_init_ident(mat4x4f* me);
 void omat4x4f_init_perspective(mat4x4f* me, float fov_rad, float aspect, float znear, float zfar);
+void omat4x4f_init_frustum(mat4x4f* me, float left, float right, float bottom, float top, float znear, float zfar);
 void omat4x4f_init_look_at(mat4x4f* me, const quatf* ret, const vec3f* eye);
 void omat4x4f_init_translate(mat4x4f* me, float x, float y, float z);
 void omat4x4f_mult(const mat4x4f* left, const mat4x4f* right, mat4x4f* out_mat);


### PR DESCRIPTION
Here's code to use an asymmetric frustum and actually compute the FoV of the Rift devices from values reported by the hardware. The same technique can probably be applied to the other HMDs