### PR TITLE
oops, missing minus sign in make_frustum

### DIFF
--- a/src/omath.c
+++ b/src/omath.c
@@ -273,8 +273,8 @@ void omat4x4f_init_frustum(mat4x4f* me, float left, float right, float bottom, f
 
 	me->m[2][0] = 0;
 	me->m[2][1] = 0;
-	me->m[2][2] = (zfar + znear) / delta_z;
-	me->m[2][3] = 2.0f * zfar * znear / delta_z;
+	me->m[2][2] = -(zfar + znear) / delta_z;
+	me->m[2][3] = -2.0f * zfar * znear / delta_z;
 
 	me->m[3][0] = 0;
 	me->m[3][1] = 0;


### PR DESCRIPTION
minor typo, looking between different implementations of glFrustum lead to missing 2! minus signs.  this patch adds them back and things look better.