### PR TITLE
Openglexample modernized

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ if (OPENHMD_EXAMPLE_SIMPLE)
 endif(OPENHMD_EXAMPLE_SIMPLE)
 
 if (OPENHMD_EXAMPLE_SDL)
-	find_package(SDL REQUIRED)
+	find_package(SDL2 REQUIRED)
 	find_package(GLEW REQUIRED)
 	find_package(OpenGL REQUIRED)
 	add_subdirectory(./examples/opengl)

--- a/configure.ac
+++ b/configure.ac
@@ -112,7 +112,7 @@ AM_CONDITIONAL([BUILD_OPENGL_EXAMPLE], [test "x$openglexample_enabled" != "xno"]
 
 # Libs required by OpenGL test
 AS_IF([test "x$openglexample_enabled" != "xno"], [
-	PKG_CHECK_MODULES([sdl], [sdl])
+	PKG_CHECK_MODULES([sdl2], [sdl2])
 
 	# Try to find OpenGL with pkg-config
 	PKG_CHECK_MODULES([GL], [gl], [],

--- a/examples/opengl/CMakeLists.txt
+++ b/examples/opengl/CMakeLists.txt
@@ -1,5 +1,5 @@
 project (openglexample)
-include_directories(${CMAKE_BINARY_DIR}/include ${SDL_INCLUDE_DIR} ${GLEW_INCLUDE_DIRS} ${OPENGL_INCLUDE_DIR})
+include_directories(${CMAKE_BINARY_DIR}/include ${SDL2_INCLUDE_DIRS} ${GLEW_INCLUDE_DIRS} ${OPENGL_INCLUDE_DIR})
 link_directories(${CMAKE_BINARY_DIR})
-link_libraries (openhmd m ${SDL_LIBRARY} ${GLEW_LIBRARIES} ${OPENGL_LIBRARIES})
+link_libraries (openhmd m ${SDL2_LIBRARIES} ${GLEW_LIBRARIES} ${OPENGL_LIBRARIES})
 add_executable(openglexample gl.c main.c)

--- a/examples/opengl/Makefile.am
+++ b/examples/opengl/Makefile.am
@@ -1,5 +1,5 @@
 bin_PROGRAMS = openglexample
-AM_CPPFLAGS = -Wall -Werror -I$(top_srcdir)/include -DOHMD_STATIC $(sdl_CFLAGS) $(GLEW_CFLAGS)
+AM_CPPFLAGS = -Wall -Werror -I$(top_srcdir)/include -DOHMD_STATIC $(sdl2_CFLAGS) $(GLEW_CFLAGS)
 openglexample_SOURCES = gl.c main.c
 openglexample_LDADD = $(top_builddir)/src/libopenhmd.la -lm
-openglexample_LDFLAGS = -static-libtool-libs $(sdl_LIBS) $(GLEW_LIBS) $(GL_LIBS)
+openglexample_LDFLAGS = -static-libtool-libs $(sdl2_LIBS) $(GLEW_LIBS) $(GL_LIBS)

--- a/examples/opengl/gl.c
+++ b/examples/opengl/gl.c
@@ -31,18 +31,31 @@ void init_gl(gl_ctx* ctx, int w, int h)
 	}
 
 	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-	SDL_GL_SetAttribute(SDL_GL_SWAP_CONTROL, 1);
 
-	ctx->screen = SDL_SetVideoMode(w, h, 0, SDL_OPENGL | SDL_GL_DOUBLEBUFFER);
-	if(ctx->screen == NULL){
-		printf("SDL_SetVideoMode failed\n");
+	ctx->window = SDL_CreateWindow("OpenHMD opengl example",
+			SDL_WINDOWPOS_UNDEFINED,
+			SDL_WINDOWPOS_UNDEFINED,
+			w, h, SDL_WINDOW_OPENGL );
+	if(ctx->window == NULL) {
+		printf("SDL_CreateWindow failed\n");
+		exit(-1);
+	}
+	ctx->w = w;
+	ctx->h = h;
+	ctx->is_fullscreen = 0;
+
+	ctx->glcontext = SDL_GL_CreateContext(ctx->window);
+	if(ctx->glcontext == NULL){
+		printf("SDL_GL_CreateContext\n");
 		exit(-1);
 	}
 
+	SDL_GL_SetSwapInterval(1);
+
 	// Disable ctrl-c catching on linux (and OS X?) 
-	#ifdef __unix
+#ifdef __unix
 	signal(SIGINT, SIG_DFL);
-	#endif
+#endif
 
 	// Load extensions.
 	glewInit();
@@ -69,7 +82,7 @@ void init_gl(gl_ctx* ctx, int w, int h)
 	glEnable(GL_POLYGON_SMOOTH); 
 	glLoadIdentity();
 
-	glViewport(0, 0, ctx->screen->w, ctx->screen->h);
+	glViewport(0, 0, ctx->w, ctx->h);
 }
 
 void ortho(gl_ctx* ctx)
@@ -78,7 +91,7 @@ void ortho(gl_ctx* ctx)
 	//glPushMatrix();
 	glLoadIdentity();
 
-	glOrtho(0.0f, ctx->screen->w, ctx->screen->h, 0.0f, -1.0f, 1.0f);
+	glOrtho(0.0f, ctx->w, ctx->h, 0.0f, -1.0f, 1.0f);
 	glMatrixMode(GL_MODELVIEW);
 	//glPushMatrix();
 	glLoadIdentity();

--- a/examples/opengl/gl.h
+++ b/examples/opengl/gl.h
@@ -17,7 +17,9 @@
 
 typedef struct {
 	int w, h;
-	SDL_Surface* screen;
+	SDL_Window* window;
+	SDL_GLContext glcontext;
+	int is_fullscreen;
 } gl_ctx;
 
 void ortho(gl_ctx* ctx);

--- a/examples/opengl/main.c
+++ b/examples/opengl/main.c
@@ -156,7 +156,6 @@ int main(int argc, char** argv)
 	glUniform1i(glGetUniformLocation(shader, "warpTexture"), 0);
 	glUniform2fv(glGetUniformLocation(shader, "ViewportScale"), 1, viewport_scale);
 	glUniform1f(glGetUniformLocation(shader, "WarpScale"), warp_scale);
-	glUniform4fv(glGetUniformLocation(shader, "HmdWarpParam"), 1, distortion_coeffs);
 	glUniform3fv(glGetUniformLocation(shader, "aberr"), 1, aberr_scale);
 	glUseProgram(0);
 
@@ -209,11 +208,26 @@ int main(int argc, char** argv)
 						print_matrix(mat);
 						printf("\n");
 						printf("viewport_scale: [%0.4f, %0.4f]\n", viewport_scale[0], viewport_scale[1]);
+						printf("lens separation: %04f\n", sep);
 						printf("warp_scale: %0.4f\r\n", warp_scale);
 						printf("distoriton coeffs: [%0.4f, %0.4f, %0.4f, %0.4f]\n", distortion_coeffs[0], distortion_coeffs[1], distortion_coeffs[2], distortion_coeffs[3]);
 						printf("aberration coeffs: [%0.4f, %0.4f, %0.4f]\n", aberr_scale[0], aberr_scale[1], aberr_scale[2]);
 						printf("left_lens_center: [%0.4f, %0.4f]\n", left_lens_center[0], left_lens_center[1]);
-						printf("right_lens_center: [%0.4f, %0.4f]\n", left_lens_center[0], left_lens_center[1]);
+						printf("right_lens_center: [%0.4f, %0.4f]\n", right_lens_center[0], right_lens_center[1]);
+					}
+					break;
+				case SDLK_d:
+					/* toggle between distorted and undistorted views */
+					if ((distortion_coeffs[0] != 0.0) ||
+							(distortion_coeffs[1] != 0.0) ||
+							(distortion_coeffs[2] != 0.0) ||
+							(distortion_coeffs[3] != 1.0)) {
+						distortion_coeffs[0] = 0.0;
+						distortion_coeffs[1] = 0.0;
+						distortion_coeffs[2] = 0.0;
+						distortion_coeffs[3] = 1.0;
+					} else {
+						ohmd_device_getf(hmd, OHMD_UNIVERSAL_DISTORTION_K, &(distortion_coeffs[0]));
 					}
 					break;
 				default:
@@ -266,6 +280,7 @@ int main(int argc, char** argv)
 
 		// Setup ortho state.
 		glUseProgram(shader);
+		glUniform4fv(glGetUniformLocation(shader, "HmdWarpParam"), 1, distortion_coeffs);
 		glViewport(0, 0, hmd_w, hmd_h);
 		glEnable(GL_TEXTURE_2D);
 		glColor4d(1, 1, 1, 1);

--- a/examples/opengl/main.c
+++ b/examples/opengl/main.c
@@ -241,6 +241,16 @@ int main(int argc, char** argv)
 						printf("right_lens_center: [%0.4f, %0.4f]\n", right_lens_center[0], right_lens_center[1]);
 					}
 					break;
+				case SDLK_w:
+					sep += 0.001;
+					left_lens_center[0] = viewport_scale[0] - sep/2.0f;
+					right_lens_center[0] = sep/2.0f;
+					break;
+				case SDLK_q:
+					sep -= 0.001;
+					left_lens_center[0] = viewport_scale[0] - sep/2.0f;
+					right_lens_center[0] = sep/2.0f;
+					break;
 				case SDLK_a:
 					warp_adj *= 1.0/0.9;
 					break;

--- a/examples/opengl/main.c
+++ b/examples/opengl/main.c
@@ -154,6 +154,7 @@ int main(int argc, char** argv)
 	right_lens_center[0] = sep/2.0f;
 	//asume calibration was for lens view to which ever edge of screen is further away from lens center
 	float warp_scale = (left_lens_center[0] > right_lens_center[0]) ? left_lens_center[0] : right_lens_center[0];
+	float warp_adj = 1.0f;
 
 	ohmd_device_settings_destroy(settings);
 
@@ -176,7 +177,6 @@ int main(int argc, char** argv)
 	glUseProgram(shader);
 	glUniform1i(glGetUniformLocation(shader, "warpTexture"), 0);
 	glUniform2fv(glGetUniformLocation(shader, "ViewportScale"), 1, viewport_scale);
-	glUniform1f(glGetUniformLocation(shader, "WarpScale"), warp_scale);
 	glUniform3fv(glGetUniformLocation(shader, "aberr"), 1, aberr_scale);
 	glUseProgram(0);
 
@@ -237,6 +237,12 @@ int main(int argc, char** argv)
 						printf("left_lens_center: [%0.4f, %0.4f]\n", left_lens_center[0], left_lens_center[1]);
 						printf("right_lens_center: [%0.4f, %0.4f]\n", right_lens_center[0], right_lens_center[1]);
 					}
+					break;
+				case SDLK_a:
+					warp_adj *= 1.0/0.9;
+					break;
+				case SDLK_z:
+					warp_adj *= 0.9;
 					break;
 				case SDLK_d:
 					/* toggle between distorted and undistorted views */
@@ -317,6 +323,7 @@ int main(int argc, char** argv)
 
 		// Setup ortho state.
 		glUseProgram(shader);
+		glUniform1f(glGetUniformLocation(shader, "WarpScale"), warp_scale*warp_adj);
 		glUniform4fv(glGetUniformLocation(shader, "HmdWarpParam"), 1, distortion_coeffs);
 		glViewport(0, 0, hmd_w, hmd_h);
 		glEnable(GL_TEXTURE_2D);

--- a/examples/opengl/main.c
+++ b/examples/opengl/main.c
@@ -72,6 +72,27 @@ GLuint gen_cubes()
 	return list;
 }
 
+void draw_crosshairs(float len, float cx, float cy)
+{
+	glMatrixMode(GL_MODELVIEW);
+	glPushMatrix();
+	glLoadIdentity();
+	glMatrixMode(GL_PROJECTION);
+	glPushMatrix();
+	glLoadIdentity();
+	glBegin(GL_LINES);
+	float l = len/2.0f;
+	glVertex3f(cx - l, cy, 0.0);
+	glVertex3f(cx + l, cy, 0.0);
+	glVertex3f(cx, cy - l, 0.0);
+	glVertex3f(cx, cy + l, 0.0);
+	glEnd();
+	glMatrixMode(GL_PROJECTION);
+	glPopMatrix();
+	glMatrixMode(GL_MODELVIEW);
+	glPopMatrix();
+}
+
 void draw_scene(GLuint list)
 {
 	// draw cubes
@@ -171,6 +192,7 @@ int main(int argc, char** argv)
 
 
 	bool done = false;
+	bool crosshair_overlay = false;
 	while(!done){
 		ohmd_ctx_update(ctx);
 
@@ -230,6 +252,9 @@ int main(int argc, char** argv)
 						ohmd_device_getf(hmd, OHMD_UNIVERSAL_DISTORTION_K, &(distortion_coeffs[0]));
 					}
 					break;
+				case SDLK_x:
+					crosshair_overlay = ! crosshair_overlay;
+					break;
 				default:
 					break;
 				}
@@ -256,6 +281,12 @@ int main(int argc, char** argv)
 		glClearColor(0.0, 0.0, 0.0, 1.0);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 		draw_scene(list);
+		if (crosshair_overlay) {
+			glClear(GL_DEPTH_BUFFER_BIT);
+			glLineWidth(2.0*OVERSAMPLE_SCALE);
+			glColor4f(1.0, 0.5, 0.0, 1.0);
+			draw_crosshairs(0.1, 2*left_lens_center[0]/viewport_scale[0] - 1.0f, 2*left_lens_center[1]/viewport_scale[1] - 1.0f);
+		}
 
 		// set hmd rotation, for right eye.
 		glMatrixMode(GL_PROJECTION);
@@ -271,6 +302,12 @@ int main(int argc, char** argv)
 		glViewport(0, 0, eye_w, eye_h);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 		draw_scene(list);
+		if (crosshair_overlay) {
+			glClear(GL_DEPTH_BUFFER_BIT);
+			glLineWidth(5.0);
+			glColor4f(1.0, 0.5, 0.0, 1.0);
+			draw_crosshairs(0.1, 2*right_lens_center[0]/viewport_scale[0] - 1.0f, 2*right_lens_center[1]/viewport_scale[1] - 1.0f);
+		}
 
 		// Clean up common draw state
 		glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);

--- a/examples/opengl/main.c
+++ b/examples/opengl/main.c
@@ -206,7 +206,10 @@ int main(int argc, char** argv)
 					done = true;
 					break;
 				case SDLK_F1:
-					SDL_WM_ToggleFullScreen(gl.screen);
+					{
+						gl.is_fullscreen = !gl.is_fullscreen;
+						SDL_SetWindowFullscreen(gl.window, gl.is_fullscreen ? SDL_WINDOW_FULLSCREEN : 0);
+					}
 					break;
 				case SDLK_F2:
 					{
@@ -390,7 +393,7 @@ int main(int argc, char** argv)
 		glUseProgram(0);
 
 		// Da swap-dawup!
-		SDL_GL_SwapBuffers();
+		SDL_GL_SwapWindow(gl.window);
 		SDL_Delay(10);
 	}
 

--- a/examples/opengl/main.c
+++ b/examples/opengl/main.c
@@ -133,6 +133,8 @@ int main(int argc, char** argv)
 	ohmd_device* hmd = ohmd_list_open_device_s(ctx, 0, settings);
 	ohmd_device_geti(hmd, OHMD_SCREEN_HORIZONTAL_RESOLUTION, &hmd_w);
 	ohmd_device_geti(hmd, OHMD_SCREEN_VERTICAL_RESOLUTION, &hmd_h);
+	float ipd;
+	ohmd_device_getf(hmd, OHMD_EYE_IPD, &ipd);
 	float viewport_scale[2];
 	float distortion_coeffs[4];
 	float aberr_scale[3];
@@ -231,6 +233,7 @@ int main(int argc, char** argv)
 						printf("\n");
 						printf("viewport_scale: [%0.4f, %0.4f]\n", viewport_scale[0], viewport_scale[1]);
 						printf("lens separation: %04f\n", sep);
+						printf("IPD: %0.4f\n", ipd);
 						printf("warp_scale: %0.4f\r\n", warp_scale);
 						printf("distoriton coeffs: [%0.4f, %0.4f, %0.4f, %0.4f]\n", distortion_coeffs[0], distortion_coeffs[1], distortion_coeffs[2], distortion_coeffs[3]);
 						printf("aberration coeffs: [%0.4f, %0.4f, %0.4f]\n", aberr_scale[0], aberr_scale[1], aberr_scale[2]);
@@ -243,6 +246,14 @@ int main(int argc, char** argv)
 					break;
 				case SDLK_z:
 					warp_adj *= 0.9;
+					break;
+				case SDLK_i:
+					ipd -= 0.001;
+					ohmd_device_setf(hmd, OHMD_EYE_IPD, &ipd);
+					break;
+				case SDLK_o:
+					ipd += 0.001;
+					ohmd_device_setf(hmd, OHMD_EYE_IPD, &ipd);
 					break;
 				case SDLK_d:
 					/* toggle between distorted and undistorted views */


### PR DESCRIPTION
this updates the opengl example with a bunch of useful stuff.

- it sets the window based on the HMD reported resolution
- it uses the universal shader
- it adds crosshairs which you can use to estimate lens_sep on cv1 style adjustable IPD displays
- it allows disabling lens distortion
- it allows adjusting the distortion scale, in case of calibration FoV mismatches