### PR TITLE
fixup types and extern handling for shader sources.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,6 +10,7 @@ libopenhmd_la_SOURCES = \
 	omath.c \
 	platform-posix.c \
 	fusion.c \
+	shaders.c \
 	queue.c
 
 libopenhmd_la_LDFLAGS = -no-undefined -version-info 0:0:0

--- a/src/shaders.c
+++ b/src/shaders.c
@@ -1,4 +1,6 @@
-const char distortion_vert[] =
+#include "shaders.h"
+
+const char * const distortion_vert =
 "#version 120\n"
 "void main(void)\n"
 "{\n"
@@ -6,7 +8,7 @@ const char distortion_vert[] =
     "gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * gl_Vertex;\n"
 "}";
 
-const char distortion_frag[] =
+const char * const distortion_frag =
 "#version 120\n"
 "\n"
 "//per eye texture to warp for lens distortion\n"

--- a/src/shaders.h
+++ b/src/shaders.h
@@ -1,6 +1,6 @@
 #ifndef SHADERS_H
 #define SHADERS_H
 
-const char * const distortion_vert;
-const char * const distortion_frag;
+extern const char * const distortion_vert;
+extern const char * const distortion_frag;
 #endif /* SHADERS_H */


### PR DESCRIPTION
This fixes a bug whichcan lead to segfaults on some compilers/linkers .  Fixed the declaration to be extern int the header and const in the .c file so the linker always knows the size of the pointer and the string.