### PR TITLE
Autoconf: do not hard-code the hidapi dependency in the pkg-config file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,7 @@ PKG_PROG_PKG_CONFIG([0.24])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 hidapi="hidapi"
+AC_SUBST(hidapi)
 
 AC_SUBST(PKG_CONFIG_EXTRA_PATH, "")
 AC_SUBST(EXTRA_LD_FLAGS, "")
@@ -145,5 +146,5 @@ AC_PROG_CC
 AC_PROG_CC_C99
 
 AC_CONFIG_HEADERS([config.h])
-AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile tests/unittests/Makefile examples/Makefile examples/opengl/Makefile examples/simple/Makefile])
+AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile tests/unittests/Makefile examples/Makefile examples/opengl/Makefile examples/simple/Makefile pkg-config/openhmd.pc])
 AC_OUTPUT 

--- a/pkg-config/openhmd.pc.in
+++ b/pkg-config/openhmd.pc.in
@@ -5,7 +5,7 @@ includedir=${prefix}/include/openhmd
 Name: openhmd
 Description: API and drivers for immersive technology devices such as HMDs
 Version: 0.0.1
-Requires: hidapi-libusb
+Requires: @hidapi@
 Conflicts:
-Libs: -L${libdir} -lopenhmd
+Libs: -L${libdir} -lopenhmd -l@hidapi@
 Cflags: -I${includedir}


### PR DESCRIPTION
Let autoconf generate the pkg-config file has hidapi has not the same name on
the different platforms (hidapi or hidapi-libusb).

As we are working on the OpenHMD integration inside VLC media player, this is useful because our build system uses the OpenHMD pkg-config file to compile the VLC HMD plugin for all the platforms (even Windows).