### PR TITLE
Add missing mutex unlock in error path.

### DIFF
--- a/src/openhmd.c
+++ b/src/openhmd.c
@@ -176,8 +176,10 @@ ohmd_device* OHMD_APIENTRY ohmd_list_open_device_s(ohmd_context* ctx, int index,
 		ohmd_driver* driver = (ohmd_driver*)desc->driver_ptr;
 		ohmd_device* device = driver->open_device(driver, desc);
 
-		if (device == NULL)
+		if (device == NULL) {
+			ohmd_unlock_mutex(ctx->update_mutex);
 			return NULL;
+		}
 
 		device->rotation_correction.w = 1;
 


### PR DESCRIPTION
Otherwise deadlock when trying to open a device after first open failed.

Signed-off-by: Mario Kleiner <mario.kleiner.de@gmail.com>