### PR TITLE
Add new device setting OHMD_IDS_KEEP_ON_AT_CLOSE.

### DIFF
--- a/include/openhmd.h
+++ b/include/openhmd.h
@@ -165,6 +165,9 @@ typedef enum {
 	/** int[1] (set, default: 1): Set this to 0 to prevent OpenHMD from creating background threads to do automatic device ticking.
 	    Call ohmd_update(); must be called frequently, at least 10 times per second, if the background threads are disabled. */
 	OHMD_IDS_AUTOMATIC_UPDATE = 0,
+	/** int[1] (set, default: 0): Set this to 1 to prevent OpenHMD from trying to power off the device on ohmd_close_device().
+	    Useful to prevent device display from hot-unplugging, needed on X-Windows to have a separate-x-screen for the HMD. */
+	OHMD_IDS_KEEP_ON_AT_CLOSE = 1,
 } ohmd_int_settings;
 
 /** Button states for digital input events. */

--- a/src/drv_htc_vive/vive.c
+++ b/src/drv_htc_vive/vive.c
@@ -190,12 +190,14 @@ static void close_device(ohmd_device* device)
 
 	LOGD("closing HTC Vive device");
 
-	// turn the display off
-	hret = hid_send_feature_report(priv->hmd_handle, vive_magic_power_off1, sizeof(vive_magic_power_off1));
-	printf("power off magic 1: %d\n", hret);
+	if (!device->settings.keep_on_at_close) {
+		// turn the display off
+		hret = hid_send_feature_report(priv->hmd_handle, vive_magic_power_off1, sizeof(vive_magic_power_off1));
+		printf("power off magic 1: %d\n", hret);
 
-	hret = hid_send_feature_report(priv->hmd_handle, vive_magic_power_off2, sizeof(vive_magic_power_off2));
-	printf("power off magic 2: %d\n", hret);
+		hret = hid_send_feature_report(priv->hmd_handle, vive_magic_power_off2, sizeof(vive_magic_power_off2));
+		printf("power off magic 2: %d\n", hret);
+	}
 
 	hid_close(priv->hmd_handle);
 	hid_close(priv->imu_handle);

--- a/src/openhmd.c
+++ b/src/openhmd.c
@@ -211,6 +211,7 @@ ohmd_device* OHMD_APIENTRY ohmd_list_open_device(ohmd_context* ctx, int index)
 	ohmd_device_settings settings;
 
 	settings.automatic_update = true;
+	settings.keep_on_at_close = false;
 
 	return ohmd_list_open_device_s(ctx, index, &settings);
 }
@@ -497,6 +498,10 @@ ohmd_status OHMD_APIENTRY ohmd_device_settings_seti(ohmd_device_settings* settin
 	switch(key){
 	case OHMD_IDS_AUTOMATIC_UPDATE:
 		settings->automatic_update = val[0] == 0 ? false : true;
+		return OHMD_S_OK;
+
+	case OHMD_IDS_KEEP_ON_AT_CLOSE:
+		settings->keep_on_at_close = val[0] == 0 ? false : true;
 		return OHMD_S_OK;
 
 	default:

--- a/src/openhmdi.h
+++ b/src/openhmdi.h
@@ -84,6 +84,7 @@ typedef struct {
 struct ohmd_device_settings
 {
 	bool automatic_update;
+	bool keep_on_at_close;
 };
 
 struct ohmd_device {


### PR DESCRIPTION
This setting can be set to 1 to prevent OpenHMD from powering off
a device when it is closed with ohmd_close_device(). It defaults to
0 = try to power device off on close.

The flag so far applies to the HTC Vive. Powering off a device and
its display will cause the OS to detect the display as being unplugged.

This is, e.g., problematic in a X11 X-Server environment if one wants
to create a separate X-Screen for the video output of the HMD to gain
a performance boost and reduction in motion-to-photon latency, and to
avoid potential tearing artifacts. For best performance, the graphics
card should use page-flipping, but this only works if the HMD output
window covers the full X-Screen, so this can only be achieved if one
creates a separate X-Screen for the HMD. Separate X-Screens only work
if the HMD display is active (= "connected") while the X-Server starts,
otherwise such a separate X-Screen is discarded, iow. the separate
X-Screen is not hot-pluggable.

This flag allows to run a little helper application which opens the
HMD, e.g. during system boot, then closes it again, just to turn on
the display. Then one can (re-)start the X-Server, getting the extra
X-Screen for the HMD, and then use a VR application enjoying the
better performance and timing of this setup.

Signed-off-by: Mario Kleiner <mario.kleiner.de@gmail.com>