### PR TITLE
use position independent code with CMake too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 project(openhmd C CXX)
 set(CMAKE_C_FLAGS "-std=c99")
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 include_directories(${CMAKE_CURRENT_LIST_DIR}/include)


### PR DESCRIPTION
It's required to link libopenhmd.a into a shared library and src/Makefile.am does this too:

    libopenhmd_la_CPPFLAGS = -fPIC -I$(top_srcdir)/include -Wall