### PR TITLE
Added modified lens measurements for PSVR.

### DIFF
--- a/src/drv_psvr/psvr.c
+++ b/src/drv_psvr/psvr.c
@@ -225,8 +225,12 @@ static ohmd_device* open_device(ohmd_driver* driver, ohmd_device_desc* desc)
 	priv->base.properties.vsize = 0.071; //from calculated specs
 	priv->base.properties.hres = 1920;
 	priv->base.properties.vres = 1080;
-	priv->base.properties.lens_sep = 0.063500;
-	priv->base.properties.lens_vpos = 0.049694;
+
+	// Measurements taken from
+	// https://github.com/gusmanb/PSVRFramework/wiki/Optical-characteristics
+	priv->base.properties.lens_sep = 0.0630999878f;
+	priv->base.properties.lens_vpos = 0.0394899882f;
+
 	priv->base.properties.fov = DEG_TO_RAD(103.57f); //TODO: Confirm exact mesurements
 	priv->base.properties.ratio = (1920.0f / 1080.0f) / 2.0f;
 


### PR DESCRIPTION
Okay, so in an effort to improve the PSVR support on the driver, I noticed that the in the openglexample, there is a mode to test a crosshair overlay and it is very off-centre in PSVR. In order to adjust this, I took the measurements from https://github.com/gusmanb/PSVRFramework/wiki/Optical-characteristics, and I 'think' they're correct, but I would like to get a second opinion on this. They're likely an improvement over the previous values either way since they were just taken straight from the Vive verbatim.