### PR TITLE
GearVR (gen1) support

### DIFF
--- a/src/drv_oculus_rift/rift.c
+++ b/src/drv_oculus_rift/rift.c
@@ -44,11 +44,14 @@ typedef struct {
 typedef enum {
 	REV_DK1,
 	REV_DK2,
-	REV_CV1
+	REV_CV1,
+
+	REV_GEARVR_GEN1
 } rift_revision;
 
 typedef struct {
 	const char* name;
+	int company;
 	int id;
 	int iface;
 	rift_revision rev;
@@ -426,21 +429,24 @@ cleanup:
 }
 
 #define OCULUS_VR_INC_ID 0x2833
-#define RIFT_ID_COUNT 4
+#define SAMSUNG_ELECTRONICS_CO_ID 0x04e8
+#define RIFT_ID_COUNT 5
 
 static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 {
 	// enumerate HID devices and add any Rifts found to the device list
 
 	rift_devices rd[RIFT_ID_COUNT] = {
-		{ "Rift (DK1)", 0x0001,	-1, REV_DK1 },
-		{ "Rift (DK2)", 0x0021,	-1, REV_DK2 },
-		{ "Rift (DK2)", 0x2021,	-1, REV_DK2 },
-		{ "Rift (CV1)", 0x0031,	 0, REV_CV1 },
+		{ "Rift (DK1)", OCULUS_VR_INC_ID, 0x0001,	-1, REV_DK1 },
+		{ "Rift (DK2)", OCULUS_VR_INC_ID, 0x0021,	-1, REV_DK2 },
+		{ "Rift (DK2)", OCULUS_VR_INC_ID, 0x2021,	-1, REV_DK2 },
+		{ "Rift (CV1)", OCULUS_VR_INC_ID, 0x0031,	 0, REV_CV1 },
+
+		{ "GearVR (Gen1)", SAMSUNG_ELECTRONICS_CO_ID, 0xa500,	 0, REV_GEARVR_GEN1 },
 	};
 
 	for(int i = 0; i < RIFT_ID_COUNT; i++){
-		struct hid_device_info* devs = hid_enumerate(OCULUS_VR_INC_ID, rd[i].id);
+		struct hid_device_info* devs = hid_enumerate(rd[i].company, rd[i].id);
 		struct hid_device_info* cur_dev = devs;
 
 		if(devs == NULL)


### PR DESCRIPTION
Added GearVR Gen1 to the device list in the oculus driver, uses the exact same packet layout and is compatible with the current rift driver.

Is cheap hardware for testing!