### PR TITLE
Fix or hide most compiler warnings reported by gcc 7.3

### DIFF
--- a/src/drv_deepoon/deepoon.c
+++ b/src/drv_deepoon/deepoon.c
@@ -15,6 +15,7 @@
 #include <assert.h>
 
 #include "deepoon.h"
+#include "../hid.h"
 
 #define TICK_LEN (1.0f / 1000000.0f) // 1000 Hz ticks
 #define KEEP_ALIVE_VALUE (10 * 1000)
@@ -187,21 +188,6 @@ static void close_device(ohmd_device* device)
 	rift_priv* priv = rift_priv_get(device);
 	hid_close(priv->handle);
 	free(priv);
-}
-
-static char* _hid_to_unix_path(char* path)
-{
-	char bus [4];
-	char dev [4];
-	char *result = malloc( sizeof(char) * ( 20 + 1 ) );
-
-	sprintf (bus, "%.*s\n", 4, path);
-	sprintf (dev, "%.*s\n", 4, path + 5);
-
-	sprintf (result, "/dev/bus/usb/%03d/%03d",
-		(int)strtol(bus, NULL, 16),
-		(int)strtol(dev, NULL, 16));
-	return result;
 }
 
 static ohmd_device* open_device(ohmd_driver* driver, ohmd_device_desc* desc)

--- a/src/drv_htc_vive/vive_config.h
+++ b/src/drv_htc_vive/vive_config.h
@@ -5,6 +5,7 @@
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #pragma GCC diagnostic ignored "-Wswitch"
 #pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
+#pragma GCC diagnostic ignored "-Wmisleading-indentation"
 #include "../ext_deps/miniz.c"
 #include "../ext_deps/mjson.h"
 #pragma GCC diagnostic pop

--- a/src/drv_nolo/nolo.c
+++ b/src/drv_nolo/nolo.c
@@ -16,6 +16,7 @@
 #include <assert.h>
 
 #include "nolo.h"
+#include "../hid.h"
 
 #define NOLO_ID					0x0483 //ST microcontroller
 #define NOLO_HMD				0x5750
@@ -144,23 +145,6 @@ static void close_device(ohmd_device* device)
 	hid_close(priv->handle);
 	free(priv);
 }
-
-static char* _hid_to_unix_path(char* path)
-{
-	const int len = 16;
-	char bus [16];
-	char dev [16];
-	char *result = malloc( sizeof(char) * ( 20 + 1 ) );
-
-	sprintf (bus, "%.*s\n", len, path);
-	sprintf (dev, "%.*s\n", len, path + 5);
-
-	sprintf (result, "/dev/bus/usb/%03d/%03d",
-		(int)strtol(bus, NULL, 16),
-		(int)strtol(dev, NULL, 16));
-	return result;
-}
-
 
 void push_device(devices_t * head, drv_nolo* val) {
 	devices_t* current = head;

--- a/src/drv_nolo/nolo.c
+++ b/src/drv_nolo/nolo.c
@@ -29,11 +29,6 @@ static drv_priv* drv_priv_get(ohmd_device* device)
 	return (drv_priv*)device;
 }
 
-static int send_feature_report(drv_priv* priv, const unsigned char *data, size_t length)
-{
-	return hid_send_feature_report(priv->handle, data, length);
-}
-
 static void update_device(ohmd_device* device)
 {
 	drv_priv* priv = drv_priv_get(device);

--- a/src/drv_oculus_rift/rift.c
+++ b/src/drv_oculus_rift/rift.c
@@ -15,6 +15,7 @@
 #include <assert.h>
 
 #include "rift.h"
+#include "../hid.h"
 
 #define TICK_LEN (1.0f / 1000.0f) // 1000 Hz ticks
 #define KEEP_ALIVE_VALUE (10 * 1000)
@@ -217,21 +218,6 @@ static void close_device(ohmd_device* device)
 	rift_priv* priv = rift_priv_get(device);
 	hid_close(priv->handle);
 	free(priv);
-}
-
-static char* _hid_to_unix_path(char* path)
-{
-	char bus [5];
-	char dev [5];
-	char *result = malloc( sizeof(char) * ( 20 + 1 ) );
-
-	sprintf (bus, "%.*s", 4, path);
-	sprintf (dev, "%.*s", 4, path + 5);
-
-	sprintf (result, "/dev/bus/usb/%03d/%03d",
-		(int)strtol(bus, NULL, 16),
-		(int)strtol(dev, NULL, 16));
-	return result;
 }
 
 #define UDEV_WIKI_URL "https://github.com/OpenHMD/OpenHMD/wiki/Udev-rules-list"

--- a/src/drv_psvr/psvr.c
+++ b/src/drv_psvr/psvr.c
@@ -187,8 +187,6 @@ static ohmd_device* open_device(ohmd_driver* driver, ohmd_device_desc* desc)
 
 	priv->base.ctx = driver->ctx;
 
-	int idx = atoi(desc->path);
-
 	// Open the HMD device
 	priv->hmd_handle = open_device_idx(SONY_ID, PSVR_HMD, 0, 0, 4);
 

--- a/src/drv_wmr/wmr.c
+++ b/src/drv_wmr/wmr.c
@@ -35,7 +35,7 @@ typedef struct {
 
 } wmr_priv;
 
-static void vec3f_from_hololens_gyro(const int16_t smp[3][32], int i, vec3f* out_vec)
+static void vec3f_from_hololens_gyro(int16_t smp[3][32], int i, vec3f* out_vec)
 {
 	out_vec->x = (float)(smp[1][8*i+0] +
 			     smp[1][8*i+1] +
@@ -63,7 +63,7 @@ static void vec3f_from_hololens_gyro(const int16_t smp[3][32], int i, vec3f* out
 			     smp[2][8*i+7]) * 0.001f * -0.125f;
 }
 
-static void vec3f_from_hololens_accel(const int32_t smp[3][4], int i, vec3f* out_vec)
+static void vec3f_from_hololens_accel(int32_t smp[3][4], int i, vec3f* out_vec)
 {
 	out_vec->x = (float)smp[1][i] * 0.001f * -1.0f;
 	out_vec->y = (float)smp[0][i] * 0.001f * -1.0f;

--- a/src/hid.h
+++ b/src/hid.h
@@ -1,0 +1,15 @@
+static inline char* _hid_to_unix_path(char* path)
+{
+	char bus [5];
+	char dev [5];
+	char *result = malloc( sizeof(char) * ( 20 + 1 ) );
+
+	sprintf (bus, "%.*s", 4, path);
+	sprintf (dev, "%.*s", 4, path + 5);
+
+	sprintf (result, "/dev/bus/usb/%03d/%03d",
+		(int)strtol(bus, NULL, 16),
+		(int)strtol(dev, NULL, 16));
+	return result;
+}
+


### PR DESCRIPTION
There's still one warning left with gcc 7.3 when building via autotools or meson:

  ext_deps/mjson.c: In function ‘json_read_array’:
  ext_deps/mjson.c:612:2: warning: enumeration value ‘t_time’ not handled in switch [-Wswitch]
    switch (arr->element_type) {
    ^~~~~~
