### PR TITLE
Add Mac OSX build to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 # This is the project file for the automated build system travis (travis-ci.com).
-sudo: false
-
-dist: trusty
+matrix:
+  include:
+    - os: linux
+      sudo: false
+      dist: trusty
+    - os: osx
 
 language: c
 
@@ -13,6 +16,7 @@ addons:
       - libhidapi-dev
 
 before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install hidapi; fi
   - ./autogen.sh
 
 install: true # skip install step

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # This is the project file for the automated build system travis (travis-ci.com).
-sudo: required
+sudo: false
 
 dist: trusty
 
@@ -7,9 +7,12 @@ language: c
 
 compiler: gcc
 
+addons:
+  apt:
+    packages:
+      - libhidapi-dev
+
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq libhidapi-dev
   - ./autogen.sh
 
 install: true # skip install step


### PR DESCRIPTION
With the switch to the container-based travis workers for Linux, this doesn't even increase build times significantly.