### PR TITLE
Use LOG macros to log messages in drivers

### DIFF
--- a/src/drv_htc_vive/packet.c
+++ b/src/drv_htc_vive/packet.c
@@ -92,22 +92,22 @@ bool vive_decode_config_packet(vive_config_packet* pkt, const unsigned char* buf
 
 	LOGE("Decompressed from %u to %u bytes\n", (mz_uint32)pkt->length, (mz_uint32)output_size);
 
-	//printf("Debug print all the RAW JSON things!\n%s", output);
+	//LOGD("Debug print all the RAW JSON things!\n%s", output);
 	//pUncomp should now be the uncompressed data, lets get the json from it
 	/** DEBUG JSON PARSER CODE **/
 	trim((char*)output,(char*)output,output_size);
-	//printf("%s\n",output);
+	//LOGD("%s\n",output);
 	/*
 	FILE* dfp;
 	dfp = fopen("jsondebug.json","w");
 	json_enable_debug(3, dfp);*/
 	int status = json_read_object((char*)output, sensor_offsets, NULL);
-	printf("\n--- Converted Vive JSON Data ---\n\n");
-	printf("acc_bias = %f %f %f\n", acc_bias[0], acc_bias[1], acc_bias[2]);
-	printf("acc_scale = %f %f %f\n", acc_scale[0], acc_scale[1], acc_scale[2]);
-	printf("gyro_bias = %f %f %f\n", gyro_bias[0], gyro_bias[1], gyro_bias[2]);
-	printf("gyro_scale = %f %f %f\n", gyro_scale[0], gyro_scale[1], gyro_scale[2]);
-	printf("\n--- End of Vive JSON Data ---\n\n");
+	LOGI("\n--- Converted Vive JSON Data ---\n\n");
+	LOGI("acc_bias = %f %f %f\n", acc_bias[0], acc_bias[1], acc_bias[2]);
+	LOGI("acc_scale = %f %f %f\n", acc_scale[0], acc_scale[1], acc_scale[2]);
+	LOGI("gyro_bias = %f %f %f\n", gyro_bias[0], gyro_bias[1], gyro_bias[2]);
+	LOGI("gyro_scale = %f %f %f\n", gyro_scale[0], gyro_scale[1], gyro_scale[2]);
+	LOGI("\n--- End of Vive JSON Data ---\n\n");
 
 	if (status != 0)
 		puts(json_error_string(status));

--- a/src/drv_htc_vive/vive.c
+++ b/src/drv_htc_vive/vive.c
@@ -70,7 +70,7 @@ static bool process_error(vive_priv* priv)
 
 	if(priv->gyro_q.at >= priv->gyro_q.size - 1){
 		ofq_get_mean(&priv->gyro_q, &priv->gyro_error);
-		printf("gyro error: %f, %f, %f\n", priv->gyro_error.x, priv->gyro_error.y, priv->gyro_error.z);
+		LOGE("gyro error: %f, %f, %f\n", priv->gyro_error.x, priv->gyro_error.y, priv->gyro_error.z);
 	}
 
 	return false;
@@ -192,10 +192,10 @@ static void close_device(ohmd_device* device)
 
 	// turn the display off
 	hret = hid_send_feature_report(priv->hmd_handle, vive_magic_power_off1, sizeof(vive_magic_power_off1));
-	printf("power off magic 1: %d\n", hret);
+	LOGI("power off magic 1: %d\n", hret);
 
 	hret = hid_send_feature_report(priv->hmd_handle, vive_magic_power_off2, sizeof(vive_magic_power_off2));
-	printf("power off magic 2: %d\n", hret);
+	LOGI("power off magic 2: %d\n", hret);
 
 	hid_close(priv->hmd_handle);
 	hid_close(priv->imu_handle);
@@ -213,7 +213,7 @@ static void dump_indexed_string(hid_device* device, int index)
 
 	if(hret == 0){
 		wcstombs(buffer, wbuffer, sizeof(buffer));
-		printf("indexed string 0x%02x: '%s'\n", index, buffer);
+		LOGD("indexed string 0x%02x: '%s'\n", index, buffer);
 	}
 }
 #endif
@@ -227,7 +227,7 @@ static void dump_info_string(int (*fun)(hid_device*, wchar_t*, size_t), const ch
 
 	if(hret == 0){
 		wcstombs(buffer, wbuffer, sizeof(buffer));
-		printf("%s: '%s'\n", what, buffer);
+		LOGI("%s: '%s'\n", what, buffer);
 	}
 }
 
@@ -254,11 +254,11 @@ static hid_device* open_device_idx(int manufacturer, int product, int iface, int
 	hid_device* ret = NULL;
 
 	while (cur_dev) {
-		printf("%04x:%04x %s\n", manufacturer, product, cur_dev->path);
+		LOGI("%04x:%04x %s\n", manufacturer, product, cur_dev->path);
 
 		if(idx == device_index && iface == iface_cur){
 			ret = hid_open_path(cur_dev->path);
-			printf("opening\n");
+			LOGI("opening\n");
 		}
 
 		cur_dev = cur_dev->next;
@@ -317,16 +317,16 @@ static ohmd_device* open_device(ohmd_driver* driver, ohmd_device_desc* desc)
 
 	// turn the display on
 	hret = hid_send_feature_report(priv->hmd_handle, vive_magic_power_on, sizeof(vive_magic_power_on));
-	printf("power on magic: %d\n", hret);
+	LOGI("power on magic: %d\n", hret);
 
 	// enable lighthouse
 	//hret = hid_send_feature_report(priv->hmd_handle, vive_magic_enable_lighthouse, sizeof(vive_magic_enable_lighthouse));
-	//printf("enable lighthouse magic: %d\n", hret);
+	//LOGD("enable lighthouse magic: %d\n", hret);
 
 	unsigned char buffer[128];
 	int bytes;
 
-	printf("Getting feature report 16 to 39\n");
+	LOGI("Getting feature report 16 to 39\n");
 	buffer[0] = 16;
 	bytes = hid_get_feature_report(priv->imu_handle, buffer, sizeof(buffer));
 	printf("got %i bytes\n", bytes);
@@ -346,7 +346,7 @@ static ohmd_device* open_device(ohmd_driver* driver, ohmd_device_desc* desc)
  		offset += buffer[1];
 	}
 	packet_buffer[offset] = '\0';
-	//printf("Result: %s\n", packet_buffer);
+	//LOGD("Result: %s\n", packet_buffer);
 	vive_decode_config_packet(&priv->vive_config, packet_buffer, offset);
 
 	free(packet_buffer);

--- a/src/drv_psvr/psvr.c
+++ b/src/drv_psvr/psvr.c
@@ -156,11 +156,11 @@ static hid_device* open_device_idx(int manufacturer, int product, int iface, int
 	hid_device* ret = NULL;
 
 	while (cur_dev) {
-		printf("%04x:%04x %s\n", manufacturer, product, cur_dev->path);
+		LOGI("%04x:%04x %s\n", manufacturer, product, cur_dev->path);
 
 		if(findEndPoint(cur_dev->path, device_index) > 0 && iface == iface_cur){
 			ret = hid_open_path(cur_dev->path);
-			printf("opening\n");
+			LOGI("opening\n");
 		}
 
 		cur_dev = cur_dev->next;

--- a/src/drv_wmr/wmr.c
+++ b/src/drv_wmr/wmr.c
@@ -176,11 +176,11 @@ static hid_device* open_device_idx(int manufacturer, int product, int iface, int
 	hid_device* ret = NULL;
 
 	while (cur_dev) {
-		printf("%04x:%04x %s\n", manufacturer, product, cur_dev->path);
+		LOGI("%04x:%04x %s\n", manufacturer, product, cur_dev->path);
 
 		if(idx == device_index && iface == iface_cur){
 			ret = hid_open_path(cur_dev->path);
-			printf("opening\n");
+			LOGI("opening\n");
 		}
 
 		cur_dev = cur_dev->next;
@@ -224,20 +224,20 @@ int read_config_part(wmr_priv *priv, unsigned char type,
 
 	size = config_command_sync(priv->hmd_imu, 0x0b, buf, sizeof(buf));
 	if (size != 33 || buf[0] != 0x02) {
-		printf("Failed to issue command 0b: %02x %02x %02x\n",
+		LOGE("Failed to issue command 0b: %02x %02x %02x\n",
 		       buf[0], buf[1], buf[2]);
 		return -1;
 	}
 	size = config_command_sync(priv->hmd_imu, type, buf, sizeof(buf));
 	if (size != 33 || buf[0] != 0x02) {
-		printf("Failed to issue command %02x: %02x %02x %02x\n", type,
+		LOGE("Failed to issue command %02x: %02x %02x %02x\n", type,
 		       buf[0], buf[1], buf[2]);
 		return -1;
 	}
 	for (;;) {
 		size = config_command_sync(priv->hmd_imu, 0x08, buf, sizeof(buf));
 		if (size != 33 || (buf[1] != 0x01 && buf[1] != 0x02)) {
-			printf("Failed to issue command 08: %02x %02x %02x\n",
+			LOGE("Failed to issue command 08: %02x %02x %02x\n",
 			       buf[0], buf[1], buf[2]);
 			return -1;
 		}
@@ -278,7 +278,7 @@ unsigned char *read_config(wmr_priv *priv)
 		return NULL;
 	}
 
-	printf("Read %d-byte config data\n", data_size);
+	LOGI("Read %d-byte config data\n", data_size);
 
 	return data;
 }
@@ -304,7 +304,7 @@ static ohmd_device* open_device(ohmd_driver* driver, ohmd_device_desc* desc)
 
 	config = read_config(priv);
 	if (config) {
-		printf("Model name: %.64s\n", config + 0x1c3);
+		LOGI("Model name: %.64s\n", config + 0x1c3);
 		if (strncmp((char *)(config + 0x1c3),
 			    "Samsung Windows Mixed Reality 800ZAA", 64) == 0) {
 			samsung = true;


### PR DESCRIPTION
Consistently using the LOG macros instead of printf directly could allow to add different logging backends or let applications provide a logging callback function.