### PR TITLE
cmake : remove LIB_PREFIX variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,15 +14,6 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
 option(BUILD_BOTH_STATIC_SHARED_LIB OFF)
 
-if (MSVC)
-  # Add the "lib" prefix for generated .lib outputs.
-  set(LIB_PREFIX lib)
-else (MSVC)
-  # When building with "make", "lib" prefix will be added automatically by
-  # the build tool.
-  set(LIB_PREFIX)
-endif (MSVC)
-
 #source files set just for Android
 set(openhmd_source_files
 	${CMAKE_CURRENT_LIST_DIR}/src/openhmd.c


### PR DESCRIPTION
This variable was not used so I removed it to simplify the CMakeLists.txt (I tested using MSVC).

Note that the correct variable to add a library prefix would be CMAKE_[TYPE]_PREFIX. I don't think that's a good idea to use it because an app CMake (and probably other tools) would not find the lib if it is prefixed. For example you would have to call find_library(**libopenhmd**) instead of find_library(**openmd**).