### PR TITLE
Fix external

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -97,6 +97,7 @@ if BUILD_DRIVER_EXTERNAL
 
 libopenhmd_la_SOURCES += \
 	drv_external/external.c
+libopenhmd_la_CPPFLAGS += -DDRIVER_EXTERNAL
 endif
 
 if BUILD_DRIVER_ANDROID

--- a/src/openhmd.c
+++ b/src/openhmd.c
@@ -54,12 +54,12 @@ ohmd_context* OHMD_APIENTRY ohmd_ctx_create(void)
 	ctx->drivers[ctx->num_drivers++] = ohmd_create_xgvr_drv(ctx);
 #endif
 
-#if DRIVER_EXTERNAL
-	ctx->drivers[ctx->num_drivers++] = ohmd_create_external_drv(ctx);
-#endif
-
 #if DRIVER_ANDROID
 	ctx->drivers[ctx->num_drivers++] = ohmd_create_android_drv(ctx);
+#endif
+
+#if DRIVER_EXTERNAL
+	ctx->drivers[ctx->num_drivers++] = ohmd_create_external_drv(ctx);
 #endif
 	// add dummy driver last to make it the lowest priority
 	ctx->drivers[ctx->num_drivers++] = ohmd_create_dummy_drv(ctx);


### PR DESCRIPTION
Hi,

while working on https://github.com/OpenHMD/OpenHMD/pull/165 i discovered, that the external driver will never be activated if autotools are used.

Furthermore i think that the external driver should be the driver with the second lowest priority, because the external driver always registers an HMD even if there is no one. Thereby it disables all following driver.

Kind regards,

Bernd 