### PR TITLE
wmr: fix for firmware update

### DIFF
--- a/src/drv_wmr/packet.c
+++ b/src/drv_wmr/packet.c
@@ -50,7 +50,8 @@ inline static uint64_t read64(const unsigned char** buffer)
 
 bool hololens_sensors_decode_packet(hololens_sensors_packet* pkt, const unsigned char* buffer, int size)
 {
-	if(size != 497){
+	if(size != 497 &&
+	   size != 381){
 		LOGE("invalid hololens sensor packet size (expected 497 but got %d)", size);
 		return false;
 	}

--- a/src/drv_wmr/wmr.c
+++ b/src/drv_wmr/wmr.c
@@ -119,7 +119,7 @@ static void update_device(ohmd_device* device)
 		// currently the only message type the hardware supports (I think)
 		if(buffer[0] == HOLOLENS_IRQ_SENSORS){
 			handle_tracker_sensor_msg(priv, buffer, size);
-		}else{
+		}else if(buffer[0] != HOLOLENS_IRQ_DEBUG){
 			LOGE("unknown message type: %u", buffer[0]);
 		}
 	}
@@ -209,9 +209,9 @@ static int config_command_sync(hid_device* hmd_imu, unsigned char type,
 		int size = hid_read(hmd_imu, buf, len);
 		if (size == -1)
 			return -1;
-		if (buf[0] == 0x02)
+		if (buf[0] == HOLOLENS_IRQ_CONTROL)
 			return size;
-	} while (buf[0] == 0x01);
+	} while (buf[0] == HOLOLENS_IRQ_SENSORS || buf[0] == HOLOLENS_IRQ_DEBUG);
 
 	return -1;
 }

--- a/src/drv_wmr/wmr.h
+++ b/src/drv_wmr/wmr.h
@@ -18,7 +18,8 @@
 typedef enum
 {
 	HOLOLENS_IRQ_SENSORS = 1,
-	HOLOLENS_IRQ_CONTROL = 2
+	HOLOLENS_IRQ_CONTROL = 2,
+	HOLOLENS_IRQ_DEBUG = 3,
 } hololens_sensors_irq_cmd;
 
 typedef struct


### PR DESCRIPTION
A firmware update in Oct/Nov 2018 changed the protocol of the HoloLens Sensors
device slightly. The size of the sensor report is reduced and debug messages
are now moved into a separate report.