### PR TITLE
meson: build/install openhmd.pc and header in static lib

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -107,7 +107,7 @@ endif
 
 openhmd_lib = library('openhmd', sources, include_directories : include_directories('./include'), c_args : c_args, dependencies : deps, install : true, version : library_version)
 
-# build examples and install pkg-config file + header only for shared library. shared is the default
+# build examples only for shared library. shared is the default
 if get_option('default_library') == 'shared'
 	_examples = get_option('examples')
 	if _examples.contains('simple')
@@ -124,15 +124,16 @@ if get_option('default_library') == 'shared'
 		glewdep = dependency('glew')
 		executable('openhmd_opengl_example', opengl_sources , include_directories : include_directories(['./include', 'examples/opengl']), link_with: [openhmd_lib], dependencies : [sdldep, gldep, glewdep], install : true)
 	endif
-	pkg = import('pkgconfig')
-	pkg.generate(
-		name : 'openhmd',
-		description : 'API and drivers for immersive technology devices such as HMDs',
-		version : meson.project_version(),
-		subdirs : 'openhmd',
-		requires : hidapi,
-		libraries : openhmd_lib,
-		url : 'http://www.openhmd.net/'
-	)
-	install_headers('include/openhmd.h', subdir : 'openhmd')
 endif
+
+pkg = import('pkgconfig')
+pkg.generate(
+	name : 'openhmd',
+	description : 'API and drivers for immersive technology devices such as HMDs',
+	version : meson.project_version(),
+	subdirs : 'openhmd',
+	requires : hidapi,
+	libraries : openhmd_lib,
+	url : 'http://www.openhmd.net/'
+)
+install_headers('include/openhmd.h', subdir : 'openhmd')


### PR DESCRIPTION
Generate the openhmd.pc pkgconfig file and install it and the openhmd.h
header even when building a static library.

I don't really know why it was a different case, as you usually want this header and the .pc file whenever building a library.

I don't know if it should be the same for examples too, but I'm not too concerned. I can update the PR so as to build examples when building a static library too.