### PR TITLE
VIVE Improvements

### DIFF
--- a/src/drv_htc_vive/packet.c
+++ b/src/drv_htc_vive/packet.c
@@ -105,30 +105,18 @@ bool vive_decode_config_packet(vive_imu_config* result,
                                const unsigned char* buffer,
                                uint16_t size)
 {
-	/*
-	if(size != 4069){
-		LOGE("invalid vive sensor packet size (expected 4069 but got %d)", size);
-		return false;
-	}*/
-
-	vive_config_packet pkt;
-
-	pkt.report_id = VIVE_CONFIG_READ_PACKET_ID;
-	pkt.length = size;
-
 	unsigned char output[32768];
 	mz_ulong output_size = 32768;
 
-	//int cmp_status = uncompress(pUncomp, &uncomp_len, pCmp, cmp_len);
 	int cmp_status = uncompress(output, &output_size,
-	                            buffer, (mz_ulong)pkt.length);
+	                            buffer, (mz_ulong)size);
 	if (cmp_status != Z_OK){
 		LOGE("invalid vive config, could not uncompress");
 		return false;
 	}
 
 	LOGD("Decompressed from %u to %u bytes\n",
-	     (mz_uint32)pkt.length, (mz_uint32)output_size);
+	     (mz_uint32)packet.length, (mz_uint32)output_size);
 
 	trim((char*)output, (char*)output, (unsigned int)output_size);
 

--- a/src/drv_htc_vive/packet.c
+++ b/src/drv_htc_vive/packet.c
@@ -34,12 +34,15 @@ inline static int16_t read16(const unsigned char** buffer)
 
 inline static uint32_t read32(const unsigned char** buffer)
 {
-	uint32_t ret = **buffer | (*(*buffer + 1) << 8) | (*(*buffer + 2) << 16) | (*(*buffer + 3) << 24);
+	uint32_t ret = **buffer | (*(*buffer + 1) << 8) |
+	                          (*(*buffer + 2) << 16) |
+	                          (*(*buffer + 3) << 24);
 	*buffer += 4;
 	return ret;
 }
 
-bool vive_decode_sensor_packet(vive_headset_imu_packet* pkt, const unsigned char* buffer, int size)
+bool vive_decode_sensor_packet(vive_headset_imu_packet* pkt,
+                               const unsigned char* buffer, int size)
 {
 	if(size != 52){
 		LOGE("invalid vive sensor packet size (expected 52 but got %d)", size);

--- a/src/drv_htc_vive/packet.c
+++ b/src/drv_htc_vive/packet.c
@@ -69,18 +69,18 @@ bool vive_decode_sensor_packet(vive_headset_imu_packet* pkt, const unsigned char
 //Trim function for removing tabs and spaces from string buffers
 void trim(const char* src, char* buff, const unsigned int sizeBuff)
 {
-    if(sizeBuff < 1)
-    return;
+	if(sizeBuff < 1)
+		return;
 
-    const char* current = src;
-    unsigned int i = 0;
-    while(*current != '\0' && i < sizeBuff-1)
-    {
-        if(*current != ' ' && *current != '\t' && *current != '\n')
-            buff[i++] = *current;
-        ++current;
-    }
-    buff[i] = '\0';
+	const char* current = src;
+	unsigned int i = 0;
+	while(*current != '\0' && i < sizeBuff-1)
+	{
+		if(*current != ' ' && *current != '\t' && *current != '\n')
+			buff[i++] = *current;
+		++current;
+	}
+	buff[i] = '\0';
 }
 
 void get_vec3f_from_json(const nx_json* json, const char* name, vec3f* result)
@@ -95,7 +95,7 @@ void get_vec3f_from_json(const nx_json* json, const char* name, vec3f* result)
 
 void print_vec3f(const char* title, vec3f *vec)
 {
-  LOGI("%s = %f %f %f\n", title, vec->x, vec->y, vec->z);
+	LOGI("%s = %f %f %f\n", title, vec->x, vec->y, vec->z);
 }
 
 bool vive_decode_config_packet(vive_imu_config* result,

--- a/src/drv_htc_vive/vive.c
+++ b/src/drv_htc_vive/vive.c
@@ -85,13 +85,15 @@ static bool process_error(vive_priv* priv)
 
 	if(priv->gyro_q.at >= priv->gyro_q.size - 1){
 		ofq_get_mean(&priv->gyro_q, &priv->gyro_error);
-		LOGE("gyro error: %f, %f, %f\n", priv->gyro_error.x, priv->gyro_error.y, priv->gyro_error.z);
+		LOGE("gyro error: %f, %f, %f\n",
+		     priv->gyro_error.x, priv->gyro_error.y, priv->gyro_error.z);
 	}
 
 	return false;
 }
 
-vive_headset_imu_sample* get_next_sample(vive_headset_imu_packet* pkt, int last_seq)
+vive_headset_imu_sample* get_next_sample(vive_headset_imu_packet* pkt,
+                                         int last_seq)
 {
 	int diff[3];
 
@@ -128,7 +130,7 @@ static void update_device(ohmd_device* device)
 	int size = 0;
 	unsigned char buffer[FEATURE_BUFFER_SIZE];
 
-	while((size = hid_read(priv->imu_handle, buffer, FEATURE_BUFFER_SIZE)) > 0){
+	while((size = hid_read(priv->imu_handle, buffer, FEATURE_BUFFER_SIZE)) > 0) {
 		if(buffer[0] == VIVE_HMD_IMU_PACKET_ID){
 			vive_headset_imu_packet pkt;
 			vive_decode_sensor_packet(&pkt, buffer, size);
@@ -148,7 +150,8 @@ static void update_device(ohmd_device* device)
 
 				priv->last_ticks = smp->time_ticks;
 
-				vec3f_from_vive_vec_accel(&priv->imu_config, smp->acc, &priv->raw_accel);
+				vec3f_from_vive_vec_accel(&priv->imu_config, smp->acc,
+				                          &priv->raw_accel);
 				vec3f_from_vive_vec_gyro(&priv->imu_config, smp->rot, &priv->raw_gyro);
 
 				// Fix imu orientation
@@ -174,7 +177,8 @@ static void update_device(ohmd_device* device)
 					vec3f gyro;
 					ovec3f_subtract(&priv->raw_gyro, &priv->gyro_error, &gyro);
 
-					ofusion_update(&priv->sensor_fusion, dt, &gyro, &priv->raw_accel, &mag);
+					ofusion_update(&priv->sensor_fusion, dt,
+					               &gyro, &priv->raw_accel, &mag);
 				}
 
 				priv->last_seq = smp->seq;
@@ -267,7 +271,8 @@ static void dump_indexed_string(hid_device* device, int index)
 }
 #endif
 
-static void dump_info_string(int (*fun)(hid_device*, wchar_t*, size_t), const char* what, hid_device* device)
+static void dump_info_string(int (*fun)(hid_device*, wchar_t*, size_t),
+                            const char* what, hid_device* device)
 {
 	wchar_t wbuffer[512] = {0};
 	char buffer[1024] = {0};
@@ -293,7 +298,8 @@ static void dumpbin(const char* label, const unsigned char* data, int length)
 }
 #endif
 
-static hid_device* open_device_idx(int manufacturer, int product, int iface, int iface_tot, int device_index)
+static hid_device* open_device_idx(int manufacturer, int product, int iface,
+                                   int iface_tot, int device_index)
 {
 	struct hid_device_info* devs = hid_enumerate(manufacturer, product);
 	struct hid_device_info* cur_dev = devs;
@@ -465,9 +471,11 @@ static ohmd_device* open_device(ohmd_driver* driver, ohmd_device_desc* desc)
 		goto cleanup;
 	}
 
-	dump_info_string(hid_get_manufacturer_string, "manufacturer", priv->hmd_handle);
-	dump_info_string(hid_get_product_string , "product", priv->hmd_handle);
-	dump_info_string(hid_get_serial_number_string, "serial number", priv->hmd_handle);
+	dump_info_string(hid_get_manufacturer_string,
+	                 "manufacturer", priv->hmd_handle);
+	dump_info_string(hid_get_product_string, "product", priv->hmd_handle);
+	dump_info_string(hid_get_serial_number_string,
+	                 "serial number", priv->hmd_handle);
 
 	switch (desc->revision) {
 		case REV_VIVE:
@@ -494,9 +502,13 @@ static ohmd_device* open_device(ohmd_driver* driver, ohmd_device_desc* desc)
 			LOGE("Unknown VIVE revision.\n");
 	}
 
+#if 0
 	// enable lighthouse
-	//hret = hid_send_feature_report(priv->hmd_handle, vive_magic_enable_lighthouse, sizeof(vive_magic_enable_lighthouse));
-	//LOGD("enable lighthouse magic: %d\n", hret);
+	hret = hid_send_feature_report(priv->hmd_handle,
+	                               vive_magic_enable_lighthouse,
+	                               sizeof(vive_magic_enable_lighthouse));
+	LOGD("enable lighthouse magic: %d\n", hret);
+#endif
 
 	if (vive_read_config(priv) != 0)
 	{

--- a/src/drv_htc_vive/vive.c
+++ b/src/drv_htc_vive/vive.c
@@ -350,64 +350,64 @@ int vive_read_config(vive_priv* priv)
 		buffer[0] = VIVE_CONFIG_READ_PACKET_ID;
 		bytes = hid_get_feature_report(priv->imu_handle, buffer, sizeof(buffer));
 
-    memcpy((uint8_t*)packet_buffer + offset, buffer+2, buffer[1]);
-    offset += buffer[1];
-  }
-  packet_buffer[offset] = '\0';
-  //LOGD("Result: %s\n", packet_buffer);
-  vive_decode_config_packet(&priv->imu_config, packet_buffer, offset);
+		memcpy((uint8_t*)packet_buffer + offset, buffer+2, buffer[1]);
+		offset += buffer[1];
+	}
+	packet_buffer[offset] = '\0';
+	//LOGD("Result: %s\n", packet_buffer);
+	vive_decode_config_packet(&priv->imu_config, packet_buffer, offset);
 
-  free(packet_buffer);
+	free(packet_buffer);
 
-  return 0;
+	return 0;
 }
 
 #define OHMD_GRAVITY_EARTH 9.80665 // m/s²
 
 int vive_get_range_packet(vive_priv* priv)
 {
-  unsigned char buffer[64];
+	unsigned char buffer[64];
 
-  int ret;
-  int i;
+	int ret;
+	int i;
 
-  buffer[0] = VIVE_IMU_RANGE_MODES_PACKET_ID;
+	buffer[0] = VIVE_IMU_RANGE_MODES_PACKET_ID;
 
-  ret = hid_get_feature_report(priv->imu_handle, buffer, sizeof(buffer));
-  if (ret < 0)
-    return ret;
+	ret = hid_get_feature_report(priv->imu_handle, buffer, sizeof(buffer));
+	if (ret < 0)
+		return ret;
 
-  if (!buffer[1] || !buffer[2]) {
-    ret = hid_get_feature_report(priv->imu_handle, buffer, sizeof(buffer));
-    if (ret < 0)
-      return ret;
+	if (!buffer[1] || !buffer[2]) {
+		ret = hid_get_feature_report(priv->imu_handle, buffer, sizeof(buffer));
+		if (ret < 0)
+			return ret;
 
-    if (!buffer[1] || !buffer[2]) {
-      LOGE("unexpected range mode report: %02x %02x %02x",
-        buffer[0], buffer[1], buffer[2]);
-      for (i = 0; i < 61; i++)
-        LOGE(" %02x", buffer[3+i]);
-      LOGE("\n");
-    }
-  }
+		if (!buffer[1] || !buffer[2]) {
+			LOGE("unexpected range mode report: %02x %02x %02x",
+			     buffer[0], buffer[1], buffer[2]);
+			for (i = 0; i < 61; i++)
+				LOGE(" %02x", buffer[3+i]);
+			LOGE("\n");
+		}
+	}
 
-  if (buffer[1] > 4 || buffer[2] > 4)
-    return -1;
+	if (buffer[1] > 4 || buffer[2] > 4)
+		return -1;
 
-  /*
-   * Convert MPU-6500 gyro full scale range (+/-250°/s, +/-500°/s,
-   * +/-1000°/s, or +/-2000°/s) into rad/s, accel full scale range
-   * (+/-2g, +/-4g, +/-8g, or +/-16g) into m/s².
-   */
-  double gyro_range = M_PI / 180.0 * (250 << buffer[0]);
-  priv->imu_config.gyro_range = (float) gyro_range;
-  LOGI("gyro_range %f\n", gyro_range);
+	/*
+	 * Convert MPU-6500 gyro full scale range (+/-250°/s, +/-500°/s,
+	 * +/-1000°/s, or +/-2000°/s) into rad/s, accel full scale range
+	 * (+/-2g, +/-4g, +/-8g, or +/-16g) into m/s².
+	 */
+	double gyro_range = M_PI / 180.0 * (250 << buffer[0]);
+	priv->imu_config.gyro_range = (float) gyro_range;
+	LOGI("gyro_range %f\n", gyro_range);
 
-  double acc_range = OHMD_GRAVITY_EARTH * (2 << buffer[1]);
-  priv->imu_config.acc_range = (float) acc_range;
-  LOGI("acc_range %f\n", acc_range);
+	double acc_range = OHMD_GRAVITY_EARTH * (2 << buffer[1]);
+	priv->imu_config.acc_range = (float) acc_range;
+	LOGI("acc_range %f\n", acc_range);
 
-  return 0;
+	return 0;
 }
 
 static ohmd_device* open_device(ohmd_driver* driver, ohmd_device_desc* desc)

--- a/src/drv_htc_vive/vive.h
+++ b/src/drv_htc_vive/vive.h
@@ -42,10 +42,16 @@ typedef struct
 
 typedef struct
 {
-	uint8_t report_id;
-	uint16_t length;
-	unsigned char config_data[99999];
-} vive_config_packet;
+	uint8_t id;
+	uint8_t unused[63];
+} vive_config_start_packet;
+
+typedef struct
+{
+	uint8_t id;
+	uint8_t length;
+	uint8_t payload[62];
+} vive_config_read_packet;
 
 typedef struct
 {

--- a/src/drv_htc_vive/vive.h
+++ b/src/drv_htc_vive/vive.h
@@ -24,6 +24,7 @@ typedef enum
 	VIVE_CONFIG_START_PACKET_ID = 16,
 	VIVE_CONFIG_READ_PACKET_ID = 17,
 	VIVE_HMD_IMU_PACKET_ID = 32,
+	VIVE_FIRMWARE_VERSION_PACKET_ID = 0x05
 } vive_irq_cmd;
 
 typedef struct
@@ -68,6 +69,25 @@ typedef struct
 	vec3f gyro_bias, gyro_scale;
 	float gyro_range;
 } vive_imu_config;
+
+#pragma pack(push,1)
+typedef struct
+{
+	uint8_t id;
+	uint32_t firmware_version;
+	uint32_t unknown1;
+	uint8_t string1[16];
+	uint8_t string2[16];
+	uint8_t hardware_version_micro;
+	uint8_t hardware_version_minor;
+	uint8_t hardware_version_major;
+	uint8_t hardware_revision;
+	uint32_t unknown2;
+	uint8_t fpga_version_minor;
+	uint8_t fpga_version_major;
+	uint8_t reserved[13];
+} vive_firmware_version_packet;
+#pragma pack(pop)
 
 void vec3f_from_vive_vec(const int16_t* smp, vec3f* out_vec);
 bool vive_decode_sensor_packet(vive_headset_imu_packet* pkt,


### PR DESCRIPTION
This series of patches does some style consistency in the VIVE driver, refactoring and adds small features.

* Use tabs for indent consistently
* Even though it's not the case in the whole code base, I respect a 80 char limit, which didn't need much change anyway.
* Adds the ability to retrieve the firmware version.
* Cleans up default values for the IMU config. It does not try to get these on the Pro anymore, since it's not implemented.
* Makes the packet definition for the config structs more correct, as seen in ouvrt.
* The most controversial change is most likely to not use char buffers but the struct definitions to retrieve data using `hid_get_feature_report`, as it is usually done with libusb. Not sure why this wasn't done before or why this could introduce problems. I hope that this or a similar solution is viable, since it makes the code less of a headache. 