### PR TITLE
AppVeyor: build on Windows with MSVC

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,32 @@
+os: Visual Studio 2017
+
+environment:
+  matrix:
+    - arch: x64
+      compiler: msvc2015
+    - arch: x64
+      compiler: msvc2017
+
+platform:
+  - x64
+
+install:
+  # Download ninja
+  - cmd: mkdir C:\ninja-build
+  - ps: (new-object net.webclient).DownloadFile('https://github.com/mesonbuild/cidata/raw/master/ninja.exe', 'C:\ninja-build\ninja.exe')
+  # Set paths to dependencies (based on architecture)
+  - cmd: if %arch%==x86 (set PYTHON_ROOT=C:\python37) else (set PYTHON_ROOT=C:\python37-x64)
+  # Print out dependency paths
+  - cmd: echo Using Python at %PYTHON_ROOT%
+  # Add neccessary paths to PATH variable
+  - cmd: set PATH=%cd%;C:\ninja-build;%PYTHON_ROOT%;%PYTHON_ROOT%\Scripts;%PATH%
+  # Install meson
+  - cmd: pip install meson
+  # Set up the build environment
+  - cmd: if %compiler%==msvc2015 ( call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %arch% )
+  - cmd: if %compiler%==msvc2017 ( call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %arch% )
+
+build_script:
+  - cmd: echo Building on %arch% with %compiler%
+  - cmd: meson --backend=ninja builddir -Dexamples=simple
+  - cmd: ninja -C builddir

--- a/examples/simple/simple.c
+++ b/examples/simple/simple.c
@@ -8,6 +8,7 @@
 /* Simple Test */
 
 #include <openhmd.h>
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -16,7 +17,8 @@ void ohmd_sleep(double);
 // gets float values from the device and prints them
 void print_infof(ohmd_device* hmd, const char* name, int len, ohmd_float_value val)
 {
-	float f[len];
+	float f[16];
+	assert(len <= 16);
 	ohmd_device_getf(hmd, val, f);
 	printf("%-25s", name);
 	for(int i = 0; i < len; i++)
@@ -27,7 +29,8 @@ void print_infof(ohmd_device* hmd, const char* name, int len, ohmd_float_value v
 // gets int values from the device and prints them
 void print_infoi(ohmd_device* hmd, const char* name, int len, ohmd_int_value val)
 {
-	int iv[len];
+	int iv[16];
+	assert(len <= 16);
 	ohmd_device_geti(hmd, val, iv);
 	printf("%-25s", name);
 	for(int i = 0; i < len; i++)

--- a/include/openhmd.h
+++ b/include/openhmd.h
@@ -32,7 +32,7 @@ extern "C" {
 #endif
 #else
 #define OHMD_APIENTRY
-#define OHMD_APIENTRYDLL
+#define OHMD_APIENTRYDLL __attribute__((visibility("default")))
 #endif
 
 /** Maximum length of a string, including termination, in OpenHMD. */

--- a/include/openhmd.h
+++ b/include/openhmd.h
@@ -471,6 +471,12 @@ OHMD_APIENTRYDLL void OHMD_APIENTRY ohmd_get_version(int* out_major, int* out_mi
  **/
 OHMD_APIENTRYDLL ohmd_status OHMD_APIENTRY ohmd_require_version(int major, int minor, int patch);
 
+/**
+ * Sleep for the given amount of seconds.
+ *
+ * @param time Time to sleep in seconds.
+ **/
+OHMD_APIENTRYDLL void OHMD_APIENTRY ohmd_sleep(double time);
 
 #ifdef __cplusplus
 }

--- a/meson.build
+++ b/meson.build
@@ -47,6 +47,8 @@ c_args = []
 if get_option('default_library') == 'shared'
 	if host_machine.system() == 'windows'
 		c_args += '-DDLL_EXPORT'
+	else
+		c_args += '-fvisibility=hidden'
 	endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -40,6 +40,11 @@ sources = [
 	'src/shaders.c',
 ]
 c_args = []
+if get_option('default_library') == 'shared'
+	if host_machine.system() == 'windows'
+		c_args += '-DDLL_EXPORT'
+	endif
+endif
 
 _drivers = get_option('drivers')
 if _drivers.contains('rift')

--- a/meson.build
+++ b/meson.build
@@ -17,7 +17,11 @@ if host_machine.system() == 'linux'
 endif
 
 dep_libm = meson.get_compiler('c').find_library('m', required: false)
-dep_hidapi = dependency(hidapi)
+dep_hidapi = dependency(hidapi, required : false)
+if not dep_hidapi.found()
+	proj_hidapi = subproject('hidapi')
+	dep_hidapi = proj_hidapi.get_variable('hidapi_dep')
+endif
 dep_threads = dependency('threads')
 
 deps = [

--- a/src/openhmd.c
+++ b/src/openhmd.c
@@ -17,7 +17,7 @@
 // Running automatic updates at 1000 Hz
 #define AUTOMATIC_UPDATE_SLEEP (1.0 / 1000.0)
 
-ohmd_context* OHMD_APIENTRY ohmd_ctx_create(void)
+OHMD_APIENTRYDLL ohmd_context* OHMD_APIENTRY ohmd_ctx_create(void)
 {
 	ohmd_context* ctx = calloc(1, sizeof(ohmd_context));
 	if(!ctx){
@@ -70,7 +70,7 @@ ohmd_context* OHMD_APIENTRY ohmd_ctx_create(void)
 	return ctx;
 }
 
-void OHMD_APIENTRY ohmd_ctx_destroy(ohmd_context* ctx)
+OHMD_APIENTRYDLL void OHMD_APIENTRY ohmd_ctx_destroy(ohmd_context* ctx)
 {
 	ctx->update_request_quit = true;
 
@@ -90,7 +90,7 @@ void OHMD_APIENTRY ohmd_ctx_destroy(ohmd_context* ctx)
 	free(ctx);
 }
 
-void OHMD_APIENTRY ohmd_ctx_update(ohmd_context* ctx)
+OHMD_APIENTRYDLL void OHMD_APIENTRY ohmd_ctx_update(ohmd_context* ctx)
 {
 	for(int i = 0; i < ctx->num_active_devices; i++){
 		ohmd_device* dev = ctx->active_devices[i];
@@ -104,12 +104,12 @@ void OHMD_APIENTRY ohmd_ctx_update(ohmd_context* ctx)
 	}
 }
 
-const char* OHMD_APIENTRY ohmd_ctx_get_error(ohmd_context* ctx)
+OHMD_APIENTRYDLL const char* OHMD_APIENTRY ohmd_ctx_get_error(ohmd_context* ctx)
 {
 	return ctx->error_msg;
 }
 
-int OHMD_APIENTRY ohmd_ctx_probe(ohmd_context* ctx)
+OHMD_APIENTRYDLL int OHMD_APIENTRY ohmd_ctx_probe(ohmd_context* ctx)
 {
 	memset(&ctx->list, 0, sizeof(ohmd_device_list));
 	for(int i = 0; i < ctx->num_drivers; i++){
@@ -119,7 +119,7 @@ int OHMD_APIENTRY ohmd_ctx_probe(ohmd_context* ctx)
 	return ctx->list.num_devices;
 }
 
-int OHMD_APIENTRY ohmd_gets(ohmd_string_description type, const char ** out)
+OHMD_APIENTRYDLL int OHMD_APIENTRY ohmd_gets(ohmd_string_description type, const char ** out)
 {
 	switch(type){
 	case OHMD_GLSL_DISTORTION_VERT_SRC:
@@ -145,7 +145,7 @@ int OHMD_APIENTRY ohmd_gets(ohmd_string_description type, const char ** out)
 	}
 }
 
-const char* OHMD_APIENTRY ohmd_list_gets(ohmd_context* ctx, int index, ohmd_string_value type)
+OHMD_APIENTRYDLL const char* OHMD_APIENTRY ohmd_list_gets(ohmd_context* ctx, int index, ohmd_string_value type)
 {
 	if(index >= ctx->list.num_devices)
 		return NULL;
@@ -162,7 +162,7 @@ const char* OHMD_APIENTRY ohmd_list_gets(ohmd_context* ctx, int index, ohmd_stri
 	}
 }
 
-int OHMD_APIENTRY ohmd_list_geti(ohmd_context* ctx, int index, ohmd_int_value type, int* out)
+OHMD_APIENTRYDLL int OHMD_APIENTRY ohmd_list_geti(ohmd_context* ctx, int index, ohmd_int_value type, int* out)
 {
 	if(index >= ctx->list.num_devices)
 		return OHMD_S_INVALID_PARAMETER;
@@ -210,7 +210,7 @@ static void ohmd_set_up_update_thread(ohmd_context* ctx)
 	}
 }
 
-ohmd_device* OHMD_APIENTRY ohmd_list_open_device_s(ohmd_context* ctx, int index, ohmd_device_settings* settings)
+OHMD_APIENTRYDLL ohmd_device* OHMD_APIENTRY ohmd_list_open_device_s(ohmd_context* ctx, int index, ohmd_device_settings* settings)
 {
 	ohmd_lock_mutex(ctx->update_mutex);
 
@@ -248,7 +248,7 @@ ohmd_device* OHMD_APIENTRY ohmd_list_open_device_s(ohmd_context* ctx, int index,
 	return NULL;
 }
 
-ohmd_device* OHMD_APIENTRY ohmd_list_open_device(ohmd_context* ctx, int index)
+OHMD_APIENTRYDLL ohmd_device* OHMD_APIENTRY ohmd_list_open_device(ohmd_context* ctx, int index)
 {
 	ohmd_device_settings settings;
 
@@ -257,7 +257,7 @@ ohmd_device* OHMD_APIENTRY ohmd_list_open_device(ohmd_context* ctx, int index)
 	return ohmd_list_open_device_s(ctx, index, &settings);
 }
 
-int OHMD_APIENTRY ohmd_close_device(ohmd_device* device)
+OHMD_APIENTRYDLL int OHMD_APIENTRY ohmd_close_device(ohmd_device* device)
 {
 	ohmd_lock_mutex(device->ctx->update_mutex);
 
@@ -377,7 +377,7 @@ static int ohmd_device_getf_unp(ohmd_device* device, ohmd_float_value type, floa
 	}
 }
 
-int OHMD_APIENTRY ohmd_device_getf(ohmd_device* device, ohmd_float_value type, float* out)
+OHMD_APIENTRYDLL int OHMD_APIENTRY ohmd_device_getf(ohmd_device* device, ohmd_float_value type, float* out)
 {
 	ohmd_lock_mutex(device->ctx->update_mutex);
 	int ret = ohmd_device_getf_unp(device, type, out);
@@ -438,7 +438,7 @@ int ohmd_device_setf_unp(ohmd_device* device, ohmd_float_value type, const float
 	}
 }
 
-int OHMD_APIENTRY ohmd_device_setf(ohmd_device* device, ohmd_float_value type, const float* in)
+OHMD_APIENTRYDLL int OHMD_APIENTRY ohmd_device_setf(ohmd_device* device, ohmd_float_value type, const float* in)
 {
 	ohmd_lock_mutex(device->ctx->update_mutex);
 	int ret = ohmd_device_setf_unp(device, type, in);
@@ -447,7 +447,7 @@ int OHMD_APIENTRY ohmd_device_setf(ohmd_device* device, ohmd_float_value type, c
 	return ret;
 }
 
-int OHMD_APIENTRY ohmd_device_geti(ohmd_device* device, ohmd_int_value type, int* out)
+OHMD_APIENTRYDLL int OHMD_APIENTRY ohmd_device_geti(ohmd_device* device, ohmd_int_value type, int* out)
 {
 	switch(type){
 		case OHMD_SCREEN_HORIZONTAL_RESOLUTION:
@@ -475,7 +475,7 @@ int OHMD_APIENTRY ohmd_device_geti(ohmd_device* device, ohmd_int_value type, int
 	}
 }
 
-int OHMD_APIENTRY ohmd_device_seti(ohmd_device* device, ohmd_int_value type, const int* in)
+OHMD_APIENTRYDLL int OHMD_APIENTRY ohmd_device_seti(ohmd_device* device, ohmd_int_value type, const int* in)
 {
 	switch(type){
 	default:
@@ -500,7 +500,7 @@ int ohmd_device_set_data_unp(ohmd_device* device, ohmd_data_value type, const vo
     }
 }
 
-int OHMD_APIENTRY ohmd_device_set_data(ohmd_device* device, ohmd_data_value type, const void* in)
+OHMD_APIENTRYDLL int OHMD_APIENTRY ohmd_device_set_data(ohmd_device* device, ohmd_data_value type, const void* in)
 {
 	ohmd_lock_mutex(device->ctx->update_mutex);
 	int ret = ohmd_device_set_data_unp(device, type, in);
@@ -509,7 +509,7 @@ int OHMD_APIENTRY ohmd_device_set_data(ohmd_device* device, ohmd_data_value type
 	return ret;
 }
 
-ohmd_status OHMD_APIENTRY ohmd_device_settings_seti(ohmd_device_settings* settings, ohmd_int_settings key, const int* val)
+OHMD_APIENTRYDLL ohmd_status OHMD_APIENTRY ohmd_device_settings_seti(ohmd_device_settings* settings, ohmd_int_settings key, const int* val)
 {
 	switch(key){
 	case OHMD_IDS_AUTOMATIC_UPDATE:
@@ -521,12 +521,12 @@ ohmd_status OHMD_APIENTRY ohmd_device_settings_seti(ohmd_device_settings* settin
 	}
 }
 
-ohmd_device_settings* OHMD_APIENTRY ohmd_device_settings_create(ohmd_context* ctx)
+OHMD_APIENTRYDLL ohmd_device_settings* OHMD_APIENTRY ohmd_device_settings_create(ohmd_context* ctx)
 {
 	return ohmd_alloc(ctx, sizeof(ohmd_device_settings));
 }
 
-void OHMD_APIENTRY ohmd_device_settings_destroy(ohmd_device_settings* settings)
+OHMD_APIENTRYDLL void OHMD_APIENTRY ohmd_device_settings_destroy(ohmd_device_settings* settings)
 {
 	free(settings);
 }

--- a/src/platform-posix.c
+++ b/src/platform-posix.c
@@ -89,7 +89,7 @@ uint64_t ohmd_monotonic_get(ohmd_context* ctx)
 
 #endif
 
-void ohmd_sleep(double seconds)
+OHMD_APIENTRYDLL void OHMD_APIENTRY ohmd_sleep(double seconds)
 {
 	struct timespec sleepfor;
 

--- a/src/platform-win32.c
+++ b/src/platform-win32.c
@@ -160,7 +160,7 @@ void ohmd_toggle_ovr_service(int state) //State is 0 for Disable, 1 for Enable
 	else if (state == 1 && _enable_ovr_service)
 	{
 		// Start it 
-		BOOL b = StartService(serviceHandle, NULL, NULL); 
+		BOOL b = StartService(serviceHandle, 0, NULL);
 		if (b) 
 			printf("OVRService started\n");
 		else 

--- a/src/platform-win32.c
+++ b/src/platform-win32.c
@@ -47,7 +47,7 @@ uint64_t ohmd_monotonic_get(ohmd_context* ctx)
 }
 
 // TODO higher resolution
-void ohmd_sleep(double seconds)
+OHMD_APIENTRYDLL void OHMD_APIENTRY ohmd_sleep(double seconds)
 {
 	Sleep((DWORD)(seconds * 1000));
 }

--- a/subprojects/hidapi.wrap
+++ b/subprojects/hidapi.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+directory = hidapi
+url = https://github.com/OpenHMD/hidapi
+revision = b245d332914021c420001292ddea1769eff17f6d


### PR DESCRIPTION
I have added a local Meson wrap for the OpenHMD hidapi fork and somehow made it build on AppVeyor. This does not include the OpenGL example yet.