### PR TITLE
vive: Add measured distortion coefficients and less wrong FOV.

### DIFF
--- a/src/drv_htc_vive/vive.c
+++ b/src/drv_htc_vive/vive.c
@@ -547,12 +547,45 @@ static ohmd_device* open_device(ohmd_driver* driver, ohmd_device_desc* desc)
 	//TODO: Confirm exact mesurements. Get for VIVE Pro.
 	priv->base.properties.hsize = 0.122822f;
 	priv->base.properties.vsize = 0.068234f;
-	priv->base.properties.lens_sep = 0.063500f;
-	priv->base.properties.lens_vpos = 0.049694f;
-	priv->base.properties.fov = DEG_TO_RAD(111.435f);
 
-	// calculate projection eye projection matrices from the device properties
-	ohmd_calc_default_proj_matrices(&priv->base.properties);
+	/*
+	 * calculated from here:
+	 * https://www.gamedev.net/topic/683698-projection-matrix-model-of-the-htc-vive/
+	 */
+	priv->base.properties.lens_sep = 0.057863;
+	priv->base.properties.lens_vpos = 0.033896;
+
+	float eye_to_screen_distance = 0.023226876441867737;
+
+	ohmd_set_universal_distortion_k(&(priv->base.properties), 1.318397, -1.490242, 0.663824, 0.508021);
+	ohmd_set_universal_aberration_k(&(priv->base.properties), 1.00010147892f, 1.000f, 1.00019614479f);
+
+	/* calculate projection eye projection matrices from the device properties */
+	float l, r, t, b, n, f;
+
+	/* left eye screen bounds */
+	l = -1.0f * (priv->base.properties.hsize / 2 - priv->base.properties.lens_sep / 2);
+	r = priv->base.properties.lens_sep / 2;
+	t = priv->base.properties.vsize - priv->base.properties.lens_vpos;
+	b = -1.0f * priv->base.properties.lens_vpos;
+	n = eye_to_screen_distance;
+	f = n * 10e6;
+
+	/* eye separation is handled by IPD in the Modelview matrix */
+	omat4x4f_init_frustum(&priv->base.properties.proj_left, l, r, b, t, n, f);
+
+	/* right eye screen bounds */
+	l = -1.0f * priv->base.properties.lens_sep / 2;
+	r = priv->base.properties.hsize / 2 - priv->base.properties.lens_sep / 2;
+	n = eye_to_screen_distance;
+	f = n * 10e6;
+
+	/* eye separation is handled by IPD in the Modelview matrix */
+	omat4x4f_init_frustum(&priv->base.properties.proj_right, l, r, b, t, n, f);
+
+	priv->base.properties.fov = 2 * atan2f(
+		priv->base.properties.hsize / 2 - priv->base.properties.lens_sep / 2,
+		eye_to_screen_distance);
 
 	// set up device callbacks
 	priv->base.update = update_device;


### PR DESCRIPTION
Based on the patch series from James Sarrett. "Add measured distortion coefficients and calculated asymmetric frustums."

Looks okay on my VIVE and VIVE Pro.

This patch was carried around by me and other people for quite some time. I rebased it to current master. It's far from perfect, but I ran into problems from current master providing a way off FOV.
Also having any kind of distortion for the VIVE is better than none.

I cleaned the patch up a bit to it's essence and applied it to current master.
