### PR TITLE
vive: Use calculated lens separation and FOV.

### DIFF
--- a/src/drv_htc_vive/vive.c
+++ b/src/drv_htc_vive/vive.c
@@ -547,12 +547,21 @@ static ohmd_device* open_device(ohmd_driver* driver, ohmd_device_desc* desc)
 	//TODO: Confirm exact mesurements. Get for VIVE Pro.
 	priv->base.properties.hsize = 0.122822f;
 	priv->base.properties.vsize = 0.068234f;
-	priv->base.properties.lens_sep = 0.063500f;
-	priv->base.properties.lens_vpos = 0.049694f;
-	priv->base.properties.fov = DEG_TO_RAD(111.435f);
 
-	// calculate projection eye projection matrices from the device properties
+	/*
+	 * calculated from here:
+	 * https://www.gamedev.net/topic/683698-projection-matrix-model-of-the-htc-vive/
+	 */
+	priv->base.properties.lens_sep = 0.057863;
+	priv->base.properties.lens_vpos = 0.033896;
+
+	/* calculate projection eye projection matrices from the device properties */
 	ohmd_calc_default_proj_matrices(&priv->base.properties);
+
+	float eye_to_screen_distance = 0.023226876441867737;
+	priv->base.properties.fov = 2 * atan2f(
+		priv->base.properties.hsize / 2 - priv->base.properties.lens_sep / 2,
+		eye_to_screen_distance);
 
 	// set up device callbacks
 	priv->base.update = update_device;


### PR DESCRIPTION
Based on the patch series from James Sarrett. "Add measured distortion coefficients and calculated asymmetric frustums."

I ran into problems from current master providing a way off FOV. The FOV and lens separation from Jason Sarrett's un-merged distortion patch is more accurate than what we have currently, which fixes some issues for me, relying on it.

Looks okay on my VIVE and VIVE Pro.