### PR TITLE
Fixing a typo in an option name in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(LIB_VERSION_STRING ${LIB_VERSION_MAJOR}.${LIB_VERSION_MINOR}.${LIB_VERSION_P
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
-option(BUILD_BOTH_STATIC_SHARED_LIB OFF)
+option(BUILD_BOTH_STATIC_SHARED_LIBS OFF)
 
 #source files set just for Android
 set(openhmd_source_files


### PR DESCRIPTION
The defined cmake option is called "BUILD_BOTH_STATIC_SHARED_LIB", which is displayed in ccmake and other tools. The variable to decide on what to build is called "BUILD_BOTH_STATIC_SHARED_LIBS" though. This results in the listed cmake option having no effect.