### PR TITLE
Meson: allow to use hidapi-hidraw on Linux

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,8 +12,17 @@ library_version = '0.1.0'
 #
 
 hidapi = 'hidapi'
+_hidapi = get_option('hidapi')
 if host_machine.system() == 'linux'
-	hidapi = 'hidapi-libusb'
+	if _hidapi == 'hidraw'
+		hidapi = 'hidapi-hidraw'
+	else
+		hidapi = 'hidapi-libusb'
+	endif
+else
+	if _hidapi != 'auto'
+		warning('hidapi option ignored on non-Linux systems')
+	endif
 endif
 
 dep_libm = meson.get_compiler('c').find_library('m', required: false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -36,3 +36,14 @@ option(
 		'external',
 	],
 )
+
+option(
+	'hidapi',
+	type: 'combo',
+	choices: [
+		'auto',
+		'libusb',
+		'hidraw'
+	],
+	value: 'auto',
+)


### PR DESCRIPTION
Add a `hidapi` combo option that can be set to `hidraw` or `libusb` on Linux to
choose the hidapi flavor. This allows to support Bluetooth HID devices such as
the Windows Mixed Reality Motion Controllers on Linux.