### PR TITLE
travis: update homebrew on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ addons:
       - hidapi
       - sdl2
       - ninja
+    update: true
 
 install:
   - if [[ "$BUILD" == "meson" && "$TRAVIS_OS_NAME" == "linux" ]]; then


### PR DESCRIPTION
Try to avoid recent build failures caused by macOS builds
not installing dependencies due to an outdated homebrew.