### PR TITLE
examples/simple: allow controls on all device types

### DIFF
--- a/examples/simple/simple.c
+++ b/examples/simple/simple.c
@@ -133,8 +133,6 @@ int main(int argc, char** argv)
 
 	printf("\n\n");
 
-	int device_class = 0;
-	ohmd_list_geti(ctx, device_idx, OHMD_DEVICE_CLASS, &device_class);
 	// Ask for n rotation quaternions and position vectors
 	for(int i = 0; i < 10000; i++){
 		ohmd_ctx_update(ctx);
@@ -150,7 +148,7 @@ int main(int argc, char** argv)
 		print_infof(hmd, "position vec: ", 3, OHMD_POSITION_VECTOR);
 
 		// read controls
-		if (device_class & OHMD_DEVICE_CLASS_CONTROLLER) {
+		if (control_count) {
 			float control_state[256];
 			ohmd_device_getf(hmd, OHMD_CONTROLS_STATE, control_state);
 


### PR DESCRIPTION
The Rift remote buttons are assigned to the Rift HMD, and there are
other HMDs that have buttons, such as the PSVR volume controls and
the Vive system button.
Show controls on HMD class devices, if they have them.