### PR TITLE
Add driver for the VR-Tek WVR headsets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(OPENHMD_DRIVER_PSVR "Sony PSVR" ON)
 option(OPENHMD_DRIVER_HTC_VIVE "HTC Vive" ON)
 option(OPENHMD_DRIVER_NOLO "NOLO VR CV1" ON)
 option(OPENHMD_DRIVER_XGVR "3Glasses HMD" ON)
+option(OPENHMD_DRIVER_VRTEK "VR-Tek HMD" ON)
 option(OPENHMD_DRIVER_EXTERNAL "External sensor driver" ON)
 option(OPENHMD_DRIVER_ANDROID "General Android driver" OFF)
 
@@ -124,6 +125,18 @@ if(OPENHMD_DRIVER_XGVR)
 	include_directories(${HIDAPI_INCLUDE_DIRS})
 	set(LIBS ${LIBS} ${HIDAPI_LIBRARIES})
 endif(OPENHMD_DRIVER_XGVR)
+
+if(OPENHMD_DRIVER_VRTEK)
+	set(openhmd_source_files ${openhmd_source_files}
+	${CMAKE_CURRENT_LIST_DIR}/src/drv_vrtek/vrtek.c
+	${CMAKE_CURRENT_LIST_DIR}/src/drv_vrtek/packet.c
+	)
+	add_definitions(-DDRIVER_VRTEK)
+
+	find_package(HIDAPI REQUIRED)
+	include_directories(${HIDAPI_INCLUDE_DIRS})
+	set(LIBS ${LIBS} ${HIDAPI_LIBRARIES})
+endif(OPENHMD_DRIVER_VRTEK)
 
 if (OPENHMD_DRIVER_EXTERNAL)
 	set(openhmd_source_files ${openhmd_source_files}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For a full list of supported devices please check https://github.com/OpenHMD/Ope
 Using Meson:
 
 With Meson, you can enable and disable drivers to compile OpenHMD with.
-Current available drivers are: rift, deepon, psvr, vive, nolo, wmr, external, and android.
+Current available drivers are: rift, deepon, psvr, vive, nolo, wmr, xgvr, vrtek, external, and android.
 These can be enabled or disabled by adding -Ddrivers=... with a comma separated list after the meson command (or using meson configure ./build -Ddrivers=...).
 By default all drivers except android are enabled.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # OpenHMD
 This project aims to provide a Free and Open Source API and drivers for immersive technology, such as head mounted displays with built in head tracking.
 
+Upstream <https://github.com/OpenHMD/OpenHMD>
+
 ## License
 OpenHMD is released under the permissive Boost Software License (see LICENSE for more information), to make sure it can be linked and distributed with both free and non-free software. While it doesn't require contribution from the users, it is still very appreciated.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # OpenHMD
 This project aims to provide a Free and Open Source API and drivers for immersive technology, such as head mounted displays with built in head tracking.
 
-Upstream <https://github.com/OpenHMD/OpenHMD>
-
 ## License
 OpenHMD is released under the permissive Boost Software License (see LICENSE for more information), to make sure it can be linked and distributed with both free and non-free software. While it doesn't require contribution from the users, it is still very appreciated.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ By default all drivers except android are enabled.
 Using CMake:
 
 With CMake, you can enable and disable drivers to compile OpenHMD with.
-Current Available drivers are: OPENHMD_DRIVER_OCULUS_RIFT, OPENHMD_DRIVER_DEEPOON, OPENHMD_DRIVER_WMR, OPENHMD_DRIVER_PSVR, OPENHMD_DRIVER_HTC_VIVE, OPENHMD_DRIVER_NOLO, OPENHMD_DRIVER_EXTERNAL and OPENHMD_DRIVER_ANDROID.
+Current Available drivers are: OPENHMD_DRIVER_OCULUS_RIFT, OPENHMD_DRIVER_DEEPOON, OPENHMD_DRIVER_PSVR, OPENHMD_DRIVER_HTC_VIVE, OPENHMD_DRIVER_NOLO, OPENHMD_DRIVER_WMR, OPENHMD_DRIVER_XGVR, OPENHMD_DRIVER_VRTEK, OPENHMD_DRIVER_EXTERNAL and OPENHMD_DRIVER_ANDROID.
 These can be enabled or disabled adding -DDRIVER_OF_CHOICE=ON after the cmake command (or using cmake-gui).
 
     mkdir build

--- a/meson.build
+++ b/meson.build
@@ -130,6 +130,15 @@ if _drivers.contains('xgvr')
 	deps += dep_hidapi
 endif
 
+if _drivers.contains('vrtek')
+	sources += [
+		'src/drv_vrtek/vrtek.c',
+		'src/drv_vrtek/packet.c',
+	]
+	c_args += '-DDRIVER_VRTEK'
+	deps += dep_hidapi
+endif
+
 if _drivers.contains('external')
 	sources += [
 		'src/drv_external/external.c',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,6 +22,7 @@ option(
 		'nolo',
 		'wmr',
 		'xgvr',
+		'vrtek',
 		'external',
 		'android',
 	],
@@ -33,6 +34,7 @@ option(
 		'nolo',
 		'wmr',
 		'xgvr',
+		'vrtek',
 		'external',
 	],
 )

--- a/src/drv_oculus_rift/rift.c
+++ b/src/drv_oculus_rift/rift.c
@@ -1076,7 +1076,10 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 			continue;
 
 		while (cur_dev) {
-			if(rd[i].iface == -1 || cur_dev->interface_number == rd[i].iface){
+			// We need to check the manufacturer because other companies (eg: VR-Tek)
+			// are reusing the Oculus DK1 USB ID for their own HMDs
+			if((wcscmp(cur_dev->manufacturer_string, L"Oculus VR, Inc.") == 0) &&
+			   (rd[i].iface == -1 || cur_dev->interface_number == rd[i].iface)) {
 				int id = 0;
 				ohmd_device_desc* desc = &list->devices[list->num_devices++];
 

--- a/src/drv_vrtek/packet.c
+++ b/src/drv_vrtek/packet.c
@@ -1,0 +1,167 @@
+// Copyright 2019, Mark Nelson.
+// SPDX-License-Identifier: BSL-1.0
+/*
+ * OpenHMD - Free and Open Source API and drivers for immersive technology.
+ */
+
+/* VR-Tek Driver */
+
+#include <stdio.h>
+#include <string.h>
+#include "vrtek.h"
+
+#ifdef _MSC_VER
+#define inline __inline
+#endif
+
+inline static uint8_t read_uint8(const uint8_t** buffer)
+{
+    uint8_t ret = **buffer;
+    *buffer += 1;
+    return ret;
+}
+
+inline static int16_t read_int16_2bu(const uint8_t** buffer)
+{
+    int16_t ret = **buffer | (*(*buffer + 1) << 8);
+    *buffer += 2;
+    return ret;
+}
+
+inline static int16_t read_int16_2bs(const uint8_t** buffer)
+{
+    const int8_t** buffer_s = (const int8_t**) buffer;
+    int16_t ret = **buffer_s | (*(*buffer_s + 1) << 8);
+    *buffer += 2;
+    return ret;
+}
+
+inline static void write_uint8(uint8_t** buffer, uint8_t val)
+{
+    **buffer = val;
+    *buffer += 1;
+}
+
+int vrtek_encode_command_packet(uint8_t command_num, uint8_t command_arg,
+                                uint8_t* data_buffer, uint8_t data_length,
+                                uint8_t* comm_packet)
+{
+    uint8_t* buffer = comm_packet;
+    write_uint8(&buffer, VRTEK_REPORT_CONTROL_OUTPUT);
+    write_uint8(&buffer, command_num);
+    write_uint8(&buffer, command_arg);
+    write_uint8(&buffer, data_length);
+
+    if (data_length) {
+        memcpy(buffer, data_buffer, data_length);
+        buffer += data_length;
+    }
+
+    uint8_t parity_byte = *comm_packet;
+    for (int i = 1; i < (data_length + 4); ++i) {
+        parity_byte ^= *(comm_packet + i);
+    }
+    write_uint8(&buffer, parity_byte);
+
+    /* return the total number of bytes in the command packet */
+    return (buffer - comm_packet);
+}
+
+int vrtek_decode_command_packet(const uint8_t* comm_packet,
+                                uint8_t* command_num, uint8_t* command_arg,
+                                uint8_t* data_buffer, uint8_t* data_length)
+{
+    const uint8_t* buffer = comm_packet;
+    uint8_t report_num = read_uint8(&buffer);
+    if (report_num != VRTEK_REPORT_CONTROL_INPUT) {
+        LOGE("received invalid report number for command packet response "
+             "(expected %d but got %d)",
+             VRTEK_REPORT_CONTROL_INPUT, report_num);
+        return -1;
+    }
+
+    *command_num = read_uint8(&buffer);
+    *command_arg = read_uint8(&buffer);
+    *data_length = read_uint8(&buffer);
+
+    if (*data_length) {
+        memcpy(data_buffer, buffer, *data_length);
+        buffer += *data_length;
+    }
+
+    uint8_t checksum = *(comm_packet + 1);
+    for (int i = 2; i < (*data_length + 4 + 1); ++i) {
+        checksum ^= *(comm_packet + i);
+    }
+
+    /* checksum should be zero if parity byte was correct */
+    if (checksum) {
+        return -2;
+    }
+
+    return 0;
+}
+
+static inline void hmd_quat_rotate(float* out, float* in)
+{
+    double pos_val = 0.707099999999999950794915548613;
+    double neg_val = -0.707099999999999950794915548613;
+
+    /* out[x] = (in[w] * 0.7071) - (in[x] * 0.7071) */
+    out[0] = (in[3] * pos_val) - (in[0] * pos_val);
+    /* out[y] = (in[z] * -0.7071) - (in[y] * 0.7071) */
+    out[1] = (in[2] * neg_val) - (in[1] * pos_val);
+    /* out[z] = (in[y] * 0.7071) - (in[z] * 0.7071) */
+    out[2] = (in[1] * pos_val) - (in[2] * pos_val);
+    /* out[w] = (in[w] * -0.7071) - (in[x] * 0.7071) */
+    out[3] = (in[3] * neg_val) - (in[0] * pos_val);
+}
+
+int vrtek_decode_hmd_data_packet(const uint8_t* buffer, int size,
+                                 vrtek_hmd_data_t* data)
+{
+    float mult = 0.00006103515625;
+    float div  = 100.0;
+    float quat[4];
+
+    if (size != 64) {
+        LOGE("received invalid VR-Tek message packet size (expected 64 bytes "
+             "but got %d)", size);
+        return -1;
+    }
+
+    /* skip report number */
+    ++buffer;
+
+    data->message_num = read_uint8(&buffer);
+
+    /* quaternion */
+    for (int i = 0; i < 4; ++i) {
+        float f = read_int16_2bu(&buffer);
+        quat[i] = f * mult;
+    }
+    hmd_quat_rotate(data->quaternion, quat);
+
+    /* euler */
+    for (int i = 0; i < 3; ++i) {
+        double d = read_int16_2bs(&buffer);
+        data->euler[i] = d / div;
+    }
+
+    /* acceleration */
+    for (int i = 0; i < 3; ++i) {
+        data->acceleration[i] = read_int16_2bu(&buffer);
+    }
+
+    /* gyroscope */
+    for (int i = 0; i < 3; ++i) {
+        data->gyroscope[i] = read_int16_2bu(&buffer);
+    }
+
+    /* magnetometer */
+    for (int i = 0; i < 3; ++i) {
+        data->magnetometer[i] = read_int16_2bu(&buffer);
+    }
+
+    return 0;
+}

--- a/src/drv_vrtek/packet.c
+++ b/src/drv_vrtek/packet.c
@@ -104,8 +104,8 @@ int vrtek_decode_command_packet(const uint8_t* comm_packet,
 
 static inline void hmd_quat_rotate(float* out, float* in)
 {
-    double pos_val = 0.707099999999999950794915548613;
-    double neg_val = -0.707099999999999950794915548613;
+    double pos_val = sin(M_PI/4);
+    double neg_val = pos_val * -1;
 
     /* out[x] = (in[w] * 0.7071) - (in[x] * 0.7071) */
     out[0] = (in[3] * pos_val) - (in[0] * pos_val);

--- a/src/drv_vrtek/vrtek.c
+++ b/src/drv_vrtek/vrtek.c
@@ -261,6 +261,15 @@ static void vrtek_update_hmd_software_version(vrtek_priv* priv,
 
     LOGI("HMD software version is 0x%4x", hmd_soft_ver);
 
+    /* This driver does not work with HMD software versions greater than
+     * 0x30010100 because the HMD packet format is different */
+    const uint32_t max_supported_hmd_soft_ver = 0x30010100;
+    if (hmd_soft_ver > max_supported_hmd_soft_ver) {
+        LOGE("HMD software version 0x%4x incompatible, expected <= 0x%4x",
+             max_supported_hmd_soft_ver, hmd_soft_ver);
+        assert(hmd_soft_ver <= 0x30010100);
+    }
+
     priv->hmd_software_version = hmd_soft_ver;
 }
 

--- a/src/drv_vrtek/vrtek.c
+++ b/src/drv_vrtek/vrtek.c
@@ -205,8 +205,10 @@ static void vrtek_update_display_properties(vrtek_priv* priv,
                                    = 1.0f;  /* (2880.0f / 1440.0f) / 2.0f */
 
             /* FIXME: work out the real values */
-            ohmd_set_universal_distortion_k(&(priv->device.properties), 0, 0, 0, 1);
-            ohmd_set_universal_aberration_k(&(priv->device.properties), 1.0, 1.0, 1.0);
+            ohmd_set_universal_distortion_k(&(priv->device.properties),
+                                            0, 0, 0, 1);
+            ohmd_set_universal_aberration_k(&(priv->device.properties),
+                                            1.0, 1.0, 1.0);
             break;
         case 5:
             /* WVR2 has one 5.5" 1440x2560 LCD rotated left*/
@@ -226,8 +228,10 @@ static void vrtek_update_display_properties(vrtek_priv* priv,
                                                / priv->device.properties.vres;
 
             /* FIXME: work out the real values */
-            ohmd_set_universal_distortion_k(&(priv->device.properties), 0, 0, 0, 1);
-            ohmd_set_universal_aberration_k(&(priv->device.properties), 1.0, 1.0, 1.0);
+            ohmd_set_universal_distortion_k(&(priv->device.properties),
+                                            0, 0, 0, 1);
+            ohmd_set_universal_aberration_k(&(priv->device.properties),
+                                            1.0, 1.0, 1.0);
             break;
         default:
             priv->display_type = VRTEK_DISP_UNKNOWN;

--- a/src/drv_vrtek/vrtek.c
+++ b/src/drv_vrtek/vrtek.c
@@ -1,0 +1,528 @@
+// Copyright 2019, Mark Nelson.
+// SPDX-License-Identifier: BSL-1.0
+/*
+ * OpenHMD - Free and Open Source API and drivers for immersive technology.
+ */
+
+/* VR-Tek Driver */
+
+#include <stdlib.h>
+#include <hidapi.h>
+#include <string.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include "vrtek.h"
+#include "../hid.h"
+
+#define VRTEK_ID       0x2833
+#define VRTEK_WVR_HMD  0x0001
+
+typedef enum {
+    VRTEK_SKU_WVR_UNKNOWN,
+    VRTEK_SKU_WVR1,
+    VRTEK_SKU_WVR2,
+    VRTEK_SKU_WVR3,
+    VRTEK_SKU_UNKNOWN_UNKNOWN
+} vrtek_hmd_sku;
+
+typedef enum {
+    VRTEK_DISP_LCD2880X1440 = 4,
+    VRTEK_DISP_LCD1440X2560_SHARP = 5,
+    VRTEK_DISP_UNKNOWN = 0xFF
+} vrtek_display_type;
+
+typedef enum {
+    VRTEK_COMMAND_CONFIGURE_HMD = 2,
+    VRTEK_COMMAND_QUERY_HMD = 3
+} vrtek_command_num;
+
+typedef enum {
+    VRTEK_CONFIG_ARG_HMD_IMU = 4
+} vrtek_config_command_arg;
+
+typedef enum {
+    VRTEK_QUERY_ARG_HMD_CONFIG = 5,
+    VRTEK_QUERY_ARG_HMD_MODEL = 7
+} vrtek_query_command_arg;
+
+#define REPORT_BUFFER_SIZE          128
+#define RESPONSE_DATA_SIZE          64
+#define MODEL_STRING_LENGTH         12
+
+typedef struct {
+    ohmd_device device;
+    hid_device* hid_handle;
+    vrtek_hmd_sku sku;
+    char model_str[MODEL_STRING_LENGTH+1];
+    uint32_t hmd_software_version;
+    vrtek_display_type display_type;
+    vrtek_hmd_data_t hmd_data;
+} vrtek_priv;
+
+static vrtek_priv* vrtek_priv_get(ohmd_device* device)
+{
+    return (vrtek_priv*)device;
+}
+
+static int vrtek_send_init(vrtek_priv* priv)
+{
+    uint8_t buf[] = { 0x1, 0x0 };
+    int ret;
+    ret = hid_write(priv->hid_handle, buf, 2);
+    LOGD("%s: sent %d bytes\n", __func__, ret);
+
+    if (ret == -1) {
+        LOGE("%s: hid_write encountered an error: %ls", __func__,
+             hid_error(priv->hid_handle));
+    }
+
+    ohmd_sleep(0.1);
+
+    return ret;
+}
+
+static int send_command_packet(vrtek_priv* priv, const uint8_t* data,
+                               size_t length)
+{
+    int ret = hid_write(priv->hid_handle, data, length);
+    LOGD("%s: sent command packet of %d bytes\n", __func__, ret);
+
+    if (ret == -1) {
+        LOGE("%s: hid_write encountered an error: %ls", __func__,
+             hid_error(priv->hid_handle));
+    } else if (ret != length) {
+        LOGE("%s: failed to send all bytes of command packet. "
+             "Sent %d, expected %lu", __func__, ret, length);
+    }
+
+    return ret;
+}
+
+static int receive_response_packet(vrtek_priv* priv, uint8_t* buf,
+                                   size_t buf_length)
+{
+    const size_t read_length = 64;
+    const int    read_timeout = 100;
+    assert(read_length <= buf_length);
+    uint8_t report_num = 0;
+    int ret = 0;
+    int hid_reads = 0;
+    const int max_hid_reads = 100;
+
+    while (report_num != VRTEK_REPORT_CONTROL_INPUT) {
+        ret = hid_read_timeout(priv->hid_handle, buf, read_length,
+                               read_timeout);
+        ++hid_reads;
+        if (ret == -1) {
+            LOGE("%s: hid_read_timeout hit an error: %ls",
+                 __func__, hid_error(priv->hid_handle));
+        }
+        else if (ret == 0) {
+            LOGW("%s: hid_read_timeout received no packet", __func__);
+        }
+
+        if (hid_reads == max_hid_reads) {
+            LOGW("%s: received %d messages that were NOT valid responses\n",
+                 __func__, hid_reads);
+
+        }
+        report_num = buf[0];
+        if (report_num == VRTEK_REPORT_SENSOR) {
+            /* skip any extraneous sensor messages */
+            LOGD("%s: skipping sensor message\n", __func__);
+            continue;
+        }
+        else if (ret != read_length) {
+            LOGW("%s: received response packet with %d bytes, but expected %lu",
+                 __func__, ret, read_length);
+        }
+    }
+
+    return ret;
+}
+
+static void vrtek_send_command_and_receive_response(vrtek_priv* priv,
+                                                    uint8_t command_num,
+                                                    uint8_t command_arg,
+                                                    uint8_t* command_data,
+                                                    uint8_t command_data_len,
+                                                    uint8_t* response_data,
+                                                    uint8_t* response_data_len)
+{
+    uint8_t buf[REPORT_BUFFER_SIZE];
+    uint8_t response_command_num;
+    uint8_t response_command_arg;
+
+    int size;
+    int result;
+
+    size = vrtek_encode_command_packet(command_num, command_arg, command_data,
+                                       command_data_len, buf);
+    result = send_command_packet(priv, buf, size);
+    assert(result != -1);
+
+    size = receive_response_packet(priv, buf, REPORT_BUFFER_SIZE);
+    assert(size == RESPONSE_DATA_SIZE);
+    result = vrtek_decode_command_packet(buf, &response_command_num,
+                                         &response_command_arg, response_data,
+                                         response_data_len);
+    assert(result == 0);
+    assert(response_command_num == command_num);
+    assert(response_command_arg == command_arg);
+}
+
+static const char* vrtek_get_display_type_string(vrtek_display_type display)
+{
+    switch(display) {
+        case VRTEK_DISP_LCD2880X1440:
+            return "2880x1440 (dual 2.89\" 1440x1440 Sharp panels)";
+        case VRTEK_DISP_LCD1440X2560_SHARP:
+            return "1440x2560 (single 5.5\" 1440x2560 Sharp panel)";
+        case VRTEK_DISP_UNKNOWN:
+            return "Unknown";
+        default:
+            assert(false);
+    }
+}
+
+static void vrtek_update_display_properties(vrtek_priv* priv,
+                                            uint8_t display_type)
+{
+    switch(display_type) {
+        case 4:
+            /* WVR3 has two 2.89" 1440x1440 LCDs */
+            priv->display_type = VRTEK_DISP_LCD2880X1440;
+            priv->device.properties.hsize = 0.103812f;
+            priv->device.properties.vsize = 0.051905f;
+            priv->device.properties.hres = 2880;
+            priv->device.properties.vres = 1440;
+            priv->device.properties.lens_sep = 0.063f;  /* FIXME */
+            priv->device.properties.lens_vpos
+                                   = priv->device.properties.vsize / 2;
+            priv->device.properties.fov = DEG_TO_RAD(100.0f);
+            priv->device.properties.ratio
+                                   = 1.0f;  /* (2880.0f / 1440.0f) / 2.0f */
+            break;
+        case 5:
+            /* WVR2 has one 5.5" 1440x2560 LCD */
+            priv->display_type = VRTEK_DISP_LCD1440X2560_SHARP;
+            priv->device.properties.hsize = 0.068040f;  /* FIXME */
+            priv->device.properties.vsize = 0.120960f;  /* FIXME */
+            priv->device.properties.hres = 1440;
+            priv->device.properties.vres = 2560;
+            priv->device.properties.lens_sep = 0.063f;  /* FIXME */
+            priv->device.properties.lens_vpos
+                                   = priv->device.properties.vsize / 2;
+            priv->device.properties.fov = DEG_TO_RAD(100.0f);
+            priv->device.properties.ratio
+                                   = (priv->device.properties.hres / 2.0f)
+                                               / priv->device.properties.vres;
+            break;
+        default:
+            priv->display_type = VRTEK_DISP_UNKNOWN;
+    }
+
+    LOGI("HMD display type is %s",
+         vrtek_get_display_type_string(priv->display_type));
+
+    /* FIXME: work out the real values */
+    ohmd_set_universal_distortion_k(&(priv->device.properties), 0, 0, 0, 1);
+    ohmd_set_universal_aberration_k(&(priv->device.properties), 1.0, 1.0, 1.0);
+}
+
+static void vrtek_update_hmd_software_version(vrtek_priv* priv,
+                                              const uint8_t* response,
+                                              uint8_t size)
+{
+    const int min_packet_response_len = 24;
+    if (size < min_packet_response_len) {
+        LOGW("unknown command packet response format (expected at least %d "
+             "bytes got %d)", min_packet_response_len, size);
+        return;
+    }
+
+    /* HMD software version starts at byte 20 in the response */
+    response += 20;
+
+    uint32_t hmd_soft_ver = (*response << 24) | (*(response + 1) << 16) |
+                            (*(response + 2) << 8) | *(response + 3);
+
+    LOGI("HMD software version is 0x%4x", hmd_soft_ver);
+
+    priv->hmd_software_version = hmd_soft_ver;
+}
+
+static const char* vrtek_get_model_string(vrtek_hmd_sku model)
+{
+    switch(model) {
+        case VRTEK_SKU_WVR_UNKNOWN:
+            return "Unknown VR-Tek WVR";
+        case VRTEK_SKU_WVR1:
+            return "VR-Tek WVR1";
+        case VRTEK_SKU_WVR2:
+            return "VR-Tek WVR2";
+        case VRTEK_SKU_WVR3:
+            return "VR-Tek WVR3";
+        case VRTEK_SKU_UNKNOWN_UNKNOWN:
+            return "Unknown HMD";
+        default:
+            assert(false);
+    }
+}
+
+static void vrtek_update_hmd_model(vrtek_priv* priv, const char* model,
+                                   uint8_t length)
+{
+    if (length < MODEL_STRING_LENGTH) {
+        priv->sku = VRTEK_SKU_UNKNOWN_UNKNOWN;
+        LOGW("unknown command packet response format (expected at least %d "
+             "bytes got %d)\n", MODEL_STRING_LENGTH, length);
+        return;
+    }
+
+    memcpy(priv->model_str, model, MODEL_STRING_LENGTH);
+    priv->model_str[12] = '\0';
+
+    /* HMD model number starts at the beginning of the response */
+    if (strncmp(model, "WVR", 3) == 0) {
+        switch(*(model + 3)) {
+            case '1':
+                priv->sku = VRTEK_SKU_WVR1;
+                break;
+            case '2':
+                priv->sku = VRTEK_SKU_WVR2;
+                break;
+            case '3':
+                priv->sku = VRTEK_SKU_WVR3;
+                break;
+            default:
+                priv->sku = VRTEK_SKU_WVR_UNKNOWN;
+                LOGW("Unknown VR-Tek HMD model: %s\n", priv->model_str);
+        }
+    }
+    else {
+        priv->sku = VRTEK_SKU_UNKNOWN_UNKNOWN;
+        LOGE("Unknown HMD model: %s\n", priv->model_str);
+        return;
+
+    }
+
+    LOGI("HMD model is %s (%s)", vrtek_get_model_string(priv->sku),
+         priv->model_str);
+}
+
+static void vrtek_set_imu_state(vrtek_priv* priv, bool state)
+{
+    uint8_t response_data[RESPONSE_DATA_SIZE];
+    uint8_t response_data_len;
+
+    uint8_t imu_state = state;  /* 1 = enabled, 0 = disabled */
+
+    vrtek_send_command_and_receive_response(priv, VRTEK_COMMAND_CONFIGURE_HMD,
+                                            VRTEK_CONFIG_ARG_HMD_IMU,
+                                            &imu_state, sizeof(uint8_t),
+                                            response_data, &response_data_len);
+    assert(response_data_len == 1);
+    assert(response_data[0] == 0);
+
+    LOGI("HMD IMU %s", imu_state ? "enabled" : "disabled");
+
+    ohmd_sleep(0.1);
+}
+
+static void vrtek_read_config(vrtek_priv* priv)
+{
+    uint8_t response_data[RESPONSE_DATA_SIZE];
+    uint8_t response_data_len;
+
+    vrtek_send_command_and_receive_response(priv, VRTEK_COMMAND_QUERY_HMD,
+                                            VRTEK_QUERY_ARG_HMD_CONFIG,
+                                            NULL, 0,
+                                            response_data, &response_data_len);
+    assert(response_data_len == 26);
+
+    /* display type is the second byte of the response */
+    uint8_t display_type = response_data[1];
+    vrtek_update_display_properties(priv, display_type);
+    vrtek_update_hmd_software_version(priv, response_data, response_data_len);
+}
+
+static void vrtek_read_model(vrtek_priv* priv)
+{
+    uint8_t response_data[RESPONSE_DATA_SIZE];
+    uint8_t response_data_len;
+
+    vrtek_send_command_and_receive_response(priv, VRTEK_COMMAND_QUERY_HMD,
+                                            VRTEK_QUERY_ARG_HMD_MODEL,
+                                            NULL, 0,
+                                            response_data, &response_data_len);
+    assert(response_data_len == 56);
+
+    const char* model = (const char*) response_data;
+    vrtek_update_hmd_model(priv, model, response_data_len);
+}
+
+static void update_device(ohmd_device* device)
+{
+    int size = 0;
+    uint8_t buf[REPORT_BUFFER_SIZE];
+    vrtek_priv* priv = vrtek_priv_get(device);
+
+    while ((size = hid_read(priv->hid_handle, buf, REPORT_BUFFER_SIZE)) > 0) {
+        if (buf[0] == VRTEK_REPORT_SENSOR) {
+            vrtek_decode_hmd_data_packet(buf, size, &priv->hmd_data);
+        } else {
+            LOGE("unknown message type: %u", buf[0]);
+        }
+    }
+
+    if (size < 0) {
+        LOGE("error reading from device");
+    }
+}
+
+static int getf(ohmd_device* device, ohmd_float_value type, float* out)
+{
+    vrtek_priv* priv = vrtek_priv_get(device);
+
+    switch (type) {
+    case OHMD_ROTATION_QUAT:
+        *(quatf*)out = *(quatf*)&priv->hmd_data.quaternion;
+        break;
+
+    case OHMD_POSITION_VECTOR:
+        out[0] = out[1] = out[2] = 0;
+        break;
+
+    case OHMD_DISTORTION_K:
+        /* FIXME: update this with real values */
+        memset(out, 0, sizeof(float) * 6);
+        break;
+
+    default:
+        ohmd_set_error(priv->device.ctx, "invalid type given to getf (%ud)",
+                       type);
+        return -1;
+        break;
+    }
+
+    return 0;
+}
+
+static void close_device(ohmd_device* device)
+{
+    LOGD("closing device");
+    vrtek_priv* priv = vrtek_priv_get(device);
+    hid_close(priv->hid_handle);
+    free(priv);
+}
+
+#define UDEV_WIKI_URL "https://github.com/OpenHMD/OpenHMD/wiki/Udev-rules-list"
+static ohmd_device* open_device(ohmd_driver* driver, ohmd_device_desc* desc)
+{
+    vrtek_priv* priv = ohmd_alloc(driver->ctx, sizeof(vrtek_priv));
+    if (!priv)
+        goto cleanup;
+
+    priv->device.ctx = driver->ctx;
+
+    /* Open the HID device */
+    priv->hid_handle = hid_open_path(desc->path);
+
+    if (!priv->hid_handle) {
+        char* path = _hid_to_unix_path(desc->path);
+        ohmd_set_error(driver->ctx, "Could not open %s.\n"
+                       "Check your permissions: "
+                       UDEV_WIKI_URL, path);
+        free(path);
+        goto cleanup;
+    }
+
+    if (hid_set_nonblocking(priv->hid_handle, 1) == -1) {
+        ohmd_set_error(driver->ctx, "failed to set non-blocking on device");
+        goto cleanup;
+    }
+
+    /* Set default device properties */
+    ohmd_set_default_device_properties(&priv->device.properties);
+
+    vrtek_send_init(priv);
+
+    /* Disable IMU */
+    vrtek_set_imu_state(priv, false);
+
+    /* Read the config */
+    vrtek_read_config(priv);
+
+    /* Read the model */
+    vrtek_read_model(priv);
+
+    /* Enable IMU */
+    vrtek_set_imu_state(priv, true);
+
+    priv->device.update = update_device;
+    priv->device.close = close_device;
+    priv->device.getf = getf;
+    priv->device.settings.automatic_update = 0;
+
+    /* calculate eye projection matrices from the device properties */
+    ohmd_calc_default_proj_matrices(&priv->device.properties);
+
+    return &priv->device;
+
+cleanup:
+    if (priv)
+        free(priv);
+
+    return NULL;
+}
+
+static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
+{
+    /* Enumerate HID devices and add any VR-Tek HMDs found to the device list */
+    struct hid_device_info* devs = hid_enumerate(VRTEK_ID, VRTEK_WVR_HMD);
+    struct hid_device_info* cur_dev = devs;
+
+    while (cur_dev) {
+        /* This is needed because VR-Tek uses the Oculus DK1 USB ID */
+        if (wcscmp(cur_dev->manufacturer_string, L"STMicroelectronics")==0 &&
+			wcscmp(cur_dev->product_string, L"HID")==0) {
+            ohmd_device_desc* desc = &list->devices[list->num_devices++];
+
+            strcpy(desc->driver, "OpenHMD VR-Tek Driver");
+            strcpy(desc->vendor, "VR-Tek");
+            strcpy(desc->product, "VR-Tek WVR");
+
+            desc->device_class = OHMD_DEVICE_CLASS_HMD;
+            desc->device_flags = OHMD_DEVICE_FLAGS_ROTATIONAL_TRACKING;
+
+            strcpy(desc->path, cur_dev->path);
+            desc->driver_ptr = driver;
+        }
+        cur_dev = cur_dev->next;
+    }
+
+    hid_free_enumeration(devs);
+}
+
+static void destroy_driver(ohmd_driver* drv)
+{
+    LOGD("Shutting down VR-Tek driver");
+    hid_exit();
+    free(drv);
+}
+
+ohmd_driver* ohmd_create_vrtek_drv(ohmd_context* ctx)
+{
+    ohmd_driver* drv = ohmd_alloc(ctx, sizeof(ohmd_driver));
+    if (drv == NULL)
+        return NULL;
+
+    drv->get_device_list = get_device_list;
+    drv->open_device = open_device;
+    drv->destroy = destroy_driver;
+    drv->ctx = ctx;
+
+    return drv;
+}

--- a/src/drv_vrtek/vrtek.c
+++ b/src/drv_vrtek/vrtek.c
@@ -15,8 +15,9 @@
 #include "vrtek.h"
 #include "../hid.h"
 
-#define VRTEK_ID       0x2833
-#define VRTEK_WVR_HMD  0x0001
+/* VR-Tek reuses the Oculus Vendor ID */
+#define OCULUS_VR_INC_ID       0x2833
+#define VRTEK_WVR_HMD          0x0001
 
 typedef enum {
     VRTEK_SKU_WVR_UNKNOWN,
@@ -500,12 +501,15 @@ cleanup:
 
 static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 {
-    /* Enumerate HID devices and add any VR-Tek HMDs found to the device list */
-    struct hid_device_info* devs = hid_enumerate(VRTEK_ID, VRTEK_WVR_HMD);
+    /* Enumerate HID devices and add any VR-Tek HMDs found to the device list.
+     * VR-Tek reuses the Oculus Vendor ID, but the manufacturer string is
+     * "STMicroelectronics" rather than "Oculus VR, Inc." and the product
+     * string is "HID". */
+    struct hid_device_info* devs = hid_enumerate(OCULUS_VR_INC_ID,
+                                                 VRTEK_WVR_HMD);
     struct hid_device_info* cur_dev = devs;
 
     while (cur_dev) {
-        /* This is needed because VR-Tek uses the Oculus DK1 USB ID */
         if (wcscmp(cur_dev->manufacturer_string, L"STMicroelectronics")==0 &&
                         wcscmp(cur_dev->product_string, L"HID")==0) {
             ohmd_device_desc* desc = &list->devices[list->num_devices++];

--- a/src/drv_vrtek/vrtek.c
+++ b/src/drv_vrtek/vrtek.c
@@ -16,40 +16,13 @@
 #include "../hid.h"
 
 /* VR-Tek reuses the Oculus Vendor ID */
-#define OCULUS_VR_INC_ID       0x2833
-#define VRTEK_WVR_HMD          0x0001
+#define OCULUS_VR_INC_ID        0x2833
+#define VRTEK_WVR_HMD           0x0001
 
-typedef enum {
-    VRTEK_SKU_WVR_UNKNOWN,
-    VRTEK_SKU_WVR1,
-    VRTEK_SKU_WVR2,
-    VRTEK_SKU_WVR3,
-    VRTEK_SKU_UNKNOWN_UNKNOWN
-} vrtek_hmd_sku;
+#define REPORT_BUFFER_SIZE      128
+#define RESPONSE_DATA_SIZE      64
 
-typedef enum {
-    VRTEK_DISP_LCD2880X1440 = 4,
-    VRTEK_DISP_LCD1440X2560_ROTATED = 5,
-    VRTEK_DISP_UNKNOWN = 0xFF
-} vrtek_display_type;
-
-typedef enum {
-    VRTEK_COMMAND_CONFIGURE_HMD = 2,
-    VRTEK_COMMAND_QUERY_HMD = 3
-} vrtek_command_num;
-
-typedef enum {
-    VRTEK_CONFIG_ARG_HMD_IMU = 4
-} vrtek_config_command_arg;
-
-typedef enum {
-    VRTEK_QUERY_ARG_HMD_CONFIG = 5,
-    VRTEK_QUERY_ARG_HMD_MODEL = 7
-} vrtek_query_command_arg;
-
-#define REPORT_BUFFER_SIZE          128
-#define RESPONSE_DATA_SIZE          64
-#define MODEL_STRING_LENGTH         12
+#define MODEL_STRING_LENGTH     12
 
 typedef struct {
     ohmd_device device;

--- a/src/drv_vrtek/vrtek.h
+++ b/src/drv_vrtek/vrtek.h
@@ -1,0 +1,41 @@
+// Copyright 2019, Mark Nelson.
+// SPDX-License-Identifier: BSL-1.0
+/*
+ * OpenHMD - Free and Open Source API and drivers for immersive technology.
+ */
+
+/* VR-Tek Driver */
+
+#ifndef VRTEK_H
+#define VRTEK_H
+
+#include <stdint.h>
+#include "../openhmdi.h"
+
+typedef struct {
+    uint8_t  message_num;
+    float    quaternion[4];
+    double   euler[3];
+    uint16_t acceleration[3];
+    uint16_t gyroscope[3];
+    uint16_t magnetometer[3];
+} vrtek_hmd_data_t;
+
+typedef enum {
+    VRTEK_REPORT_CONTROL_OUTPUT = 0x01,    /* control to HMD */
+    VRTEK_REPORT_CONTROL_INPUT  = 0x02,    /* control from HMD */
+    VRTEK_REPORT_SENSOR         = 0x13     /* sensor report from HMD */
+} vrtek_report_num;
+
+
+int vrtek_encode_command_packet(uint8_t command_num, uint8_t command_arg,
+                                uint8_t* data_buffer, uint8_t data_length,
+                                uint8_t* comm_packet);
+int vrtek_decode_command_packet(const uint8_t* comm_packet,
+                                uint8_t* command_num, uint8_t* command_arg,
+                                uint8_t* data_buffer, uint8_t* data_length);
+
+int vrtek_decode_hmd_data_packet(const uint8_t* buffer, int size,
+                                 vrtek_hmd_data_t* data);
+
+#endif

--- a/src/drv_vrtek/vrtek.h
+++ b/src/drv_vrtek/vrtek.h
@@ -27,6 +27,34 @@ typedef enum {
     VRTEK_REPORT_SENSOR         = 0x13     /* sensor report from HMD */
 } vrtek_report_num;
 
+typedef enum {
+    VRTEK_SKU_WVR_UNKNOWN,
+    VRTEK_SKU_WVR1,
+    VRTEK_SKU_WVR2,
+    VRTEK_SKU_WVR3,
+    VRTEK_SKU_UNKNOWN_UNKNOWN
+} vrtek_hmd_sku;
+
+typedef enum {
+    VRTEK_DISP_LCD2880X1440 = 4,
+    VRTEK_DISP_LCD1440X2560_ROTATED = 5,
+    VRTEK_DISP_UNKNOWN = 0xFF
+} vrtek_display_type;
+
+typedef enum {
+    VRTEK_COMMAND_CONFIGURE_HMD = 2,
+    VRTEK_COMMAND_QUERY_HMD = 3
+} vrtek_command_num;
+
+typedef enum {
+    VRTEK_CONFIG_ARG_HMD_IMU = 4
+} vrtek_config_command_arg;
+
+typedef enum {
+    VRTEK_QUERY_ARG_HMD_CONFIG = 5,
+    VRTEK_QUERY_ARG_HMD_MODEL = 7
+} vrtek_query_command_arg;
+
 
 int vrtek_encode_command_packet(uint8_t command_num, uint8_t command_arg,
                                 uint8_t* data_buffer, uint8_t data_length,

--- a/src/drv_vrtek/vrtek.h
+++ b/src/drv_vrtek/vrtek.h
@@ -13,13 +13,24 @@
 #include "../openhmdi.h"
 
 typedef struct {
-    uint8_t  message_num;
+    uint16_t message_num;
     float    quaternion[4];
     double   euler[3];
-    uint16_t acceleration[3];
-    uint16_t gyroscope[3];
-    uint16_t magnetometer[3];
+    int16_t  acceleration[3];
+    int16_t  gyroscope[3];
+    int16_t  magnetometer[3];
 } vrtek_hmd_data_t;
+
+typedef struct {
+    /* sensor fusion working data */
+    vec3f raw_gyro, raw_accel, raw_mag;
+    fusion sensor_fusion;
+
+    /* IMU config */
+    float gyro_range;
+    int16_t gyro_offset[3];    /* x, y, z */
+    float accel_range;
+} vrtek_sensor_fusion_t;
 
 typedef enum {
     VRTEK_REPORT_CONTROL_OUTPUT = 0x01,    /* control to HMD */

--- a/src/openhmd.c
+++ b/src/openhmd.c
@@ -55,6 +55,10 @@ OHMD_APIENTRYDLL ohmd_context* OHMD_APIENTRY ohmd_ctx_create(void)
 	ctx->drivers[ctx->num_drivers++] = ohmd_create_xgvr_drv(ctx);
 #endif
 
+#if DRIVER_VRTEK
+	ctx->drivers[ctx->num_drivers++] = ohmd_create_vrtek_drv(ctx);
+#endif
+
 #if DRIVER_ANDROID
 	ctx->drivers[ctx->num_drivers++] = ohmd_create_android_drv(ctx);
 #endif

--- a/src/openhmdi.h
+++ b/src/openhmdi.h
@@ -153,6 +153,7 @@ ohmd_driver* ohmd_create_wmr_drv(ohmd_context* ctx);
 ohmd_driver* ohmd_create_psvr_drv(ohmd_context* ctx);
 ohmd_driver* ohmd_create_nolo_drv(ohmd_context* ctx);
 ohmd_driver* ohmd_create_xgvr_drv(ohmd_context* ctx);
+ohmd_driver* ohmd_create_vrtek_drv(ohmd_context* ctx);
 ohmd_driver* ohmd_create_external_drv(ohmd_context* ctx);
 ohmd_driver* ohmd_create_android_drv(ohmd_context* ctx);
 


### PR DESCRIPTION
This patchset adds basic support for the VR-Tek WVR3 and WVR2 headsets made by Direkt-tek. There is also a WVR1 that could be supported, but I don't have access to a WVR1 so for now only the two higher-end models are supported.

The distortion coefficients and aberration coefficients still need work (although to be honest the display output doesn't look too bad right now), but rotational tracking is working.

These are cheap and cheerful 3DoF headsets sold by Walmart in the US:
https://www.walmart.com/ip/VR-Tek-Windows-VR-Glasses-Ultra-HD-Resolution-1440x1400-Black/56206938

Emdoor VR is the actual OEM for the headsets, with:
* WVR1 -> SpearI FHD
* WVR2 -> SpearI 2K
* WVR3 -> SpearII
http://vr.emdoor.com/en/products/PC_VR/

The headsets are reusing the USB ID of the Oculus DK1, so I added a quick test to the rift driver to check for "Oculus VR, Inc." as the manufacturer. This was just a guess though based on what I could find online. So, some input from folks who know about Oculus gear would be greatly appreciated.

Any feedback is welcome.
Thanks!