### PR TITLE
meson: hook up unit tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -223,3 +223,27 @@ pkg.generate(
 	url: 'http://www.openhmd.net/',
 )
 install_headers('include/openhmd.h', subdir: 'openhmd')
+
+
+#
+# Unit tests
+#
+
+unittests_sources = [
+	'src/omath.c',
+	'tests/unittests/highlevel.c',
+	'tests/unittests/main.c',
+	'tests/unittests/quat.c',
+	'tests/unittests/tests.h',
+	'tests/unittests/vec.c'
+]
+
+unittests = executable(
+	'openhmd_unittests',
+	unittests_sources,
+	include_directories: include_directories('./include', './src'),
+	link_with: [openhmd_lib],
+	dependencies: [dep_libm, dep_threads]
+)
+
+test('unittests', unittests)


### PR DESCRIPTION
Build the unit tests and hook them up to the ninja test target, fixes #248.