### PR TITLE
platform: remove ohmd_sleep

### DIFF
--- a/src/platform.h
+++ b/src/platform.h
@@ -14,7 +14,6 @@
 #include "openhmd.h"
 
 double ohmd_get_tick();
-void ohmd_sleep(double seconds);
 void ohmd_toggle_ovr_service(int state);
 
 typedef struct ohmd_thread ohmd_thread;


### PR DESCRIPTION
It is already defined and exported in the public openhmd header.