### PR TITLE
meson: Set OHMD_STATIC macro for static builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -62,6 +62,10 @@ if get_option('default_library') == 'shared'
 	else
 		c_args += '-fvisibility=hidden'
 	endif
+else
+	if host_machine.system() == 'windows'
+		c_args += '-DOHMD_STATIC'
+	endif
 endif
 
 _drivers = get_option('drivers')


### PR DESCRIPTION
When building a static library, define OHMD_STATIC, else there would be
linker errors due to incorrect references to the functions with the
`__imp_` prefix.

Fix #245

Without this, OpenHMD itself will refer to some of the symbols with the
`__imp_` prefix causing erros like the following:

```
libopenhmd.a(src_openhmd.c.obj):openhmd.c:(.text+0xa20): undefined reference to `__imp_ohmd_list_open_device_s'
libopenhmd.a(src_openhmd.c.obj):openhmd.c:(.text+0xa20): relocation truncated to fit: R_X86_64_PC32 against undefined symbol `__imp_ohmd_list_open_device_s'
libopenhmd.a(src_platform-win32.c.obj):platform-win32.c:(.text+0x132): undefined reference to `__imp_ohmd_sleep'
libopenhmd.a(src_platform-win32.c.obj):platform-win32.c:(.text+0x132): relocation truncated to fit: R_X86_64_PC32 against undefined symbol `__imp_ohmd_sleep'
```