### PR TITLE
meson: add an option to disable building the unit tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -242,21 +242,23 @@ install_headers('include/openhmd.h', subdir: 'openhmd')
 # Unit tests
 #
 
-unittests_sources = [
-	'src/omath.c',
-	'tests/unittests/highlevel.c',
-	'tests/unittests/main.c',
-	'tests/unittests/quat.c',
-	'tests/unittests/tests.h',
-	'tests/unittests/vec.c'
-]
+if get_option('tests')
+	unittests_sources = [
+		'src/omath.c',
+		'tests/unittests/highlevel.c',
+		'tests/unittests/main.c',
+		'tests/unittests/quat.c',
+		'tests/unittests/tests.h',
+		'tests/unittests/vec.c'
+	]
 
-unittests = executable(
-	'openhmd_unittests',
-	unittests_sources,
-	include_directories: include_directories('./include', './src'),
-	link_with: [openhmd_lib],
-	dependencies: [dep_libm, dep_threads]
-)
+	unittests = executable(
+		'openhmd_unittests',
+		unittests_sources,
+		include_directories: include_directories('./include', './src'),
+		link_with: [openhmd_lib],
+		dependencies: [dep_libm, dep_threads]
+	)
 
-test('unittests', unittests)
+	test('unittests', unittests)
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -49,3 +49,9 @@ option(
 	],
 	value: 'auto',
 )
+
+option(
+	'tests',
+	type: 'boolean',
+	value: true,
+)


### PR DESCRIPTION
The option is enabled by default, but allows to disable building the unit tests
in case of linker issues on broken build systems.

Fixes #259.