### PR TITLE
openhmd: Only export public API in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ if (POLICY CMP0072)
 	cmake_policy (SET CMP0072 NEW)
 endif(POLICY CMP0072)
 
+# policy to honor C_VISIBILITY_PRESET hidden, only exporting public ohmd api
+if (POLICY CMP0063)
+	cmake_policy(SET CMP0063 NEW)
+endif(POLICY CMP0063)
+
 set(LIB_VERSION_MAJOR 0)
 set(LIB_VERSION_MINOR 1)
 set(LIB_VERSION_PATCH 0)
@@ -187,6 +192,9 @@ if (BUILD_BOTH_STATIC_SHARED_LIBS)
 
 	set(TARGETS "openhmd-shared" "openhmd-static")
 
+	set_target_properties(openhmd-shared PROPERTIES C_VISIBILITY_PRESET hidden)
+	set_target_properties(openhmd-static PROPERTIES C_VISIBILITY_PRESET hidden)
+
 else ()
 
 	# Static or Shared
@@ -196,6 +204,7 @@ else ()
 
 	set(TARGETS "openhmd")
 
+	set_target_properties(openhmd PROPERTIES C_VISIBILITY_PRESET hidden)
 endif ()
 
 foreach(target ${TARGETS})


### PR DESCRIPTION
Checking with `nm -CD libopenhmd.so | grep " T "` shows the libopenhmd.so library built with cmake exports all defined functions (220 functions). With this change, it only exports the functions in the public openhmd API (22 functions).