### PR TITLE
Add driver to ohmd_list_gets, display device driver in simple example

### DIFF
--- a/examples/simple/simple.c
+++ b/examples/simple/simple.c
@@ -75,6 +75,7 @@ int main(int argc, char** argv)
 		printf("  vendor:  %s\n", ohmd_list_gets(ctx, i, OHMD_VENDOR));
 		printf("  product: %s\n", ohmd_list_gets(ctx, i, OHMD_PRODUCT));
 		printf("  path:    %s\n", ohmd_list_gets(ctx, i, OHMD_PATH));
+		printf("  driver:  %s\n", ohmd_list_gets(ctx, i, OHMD_DRIVER));
 		printf("  class:   %s\n", device_class_s[device_class > OHMD_DEVICE_CLASS_GENERIC_TRACKER ? 4 : device_class]);
 		printf("  flags:   %02x\n",  device_flags);
 		printf("    null device:         %s\n", device_flags & OHMD_DEVICE_FLAGS_NULL_DEVICE ? "yes" : "no");

--- a/include/openhmd.h
+++ b/include/openhmd.h
@@ -55,6 +55,7 @@ typedef enum {
 	OHMD_VENDOR    = 0,
 	OHMD_PRODUCT   = 1,
 	OHMD_PATH      = 2,
+	OHMD_DRIVER    = 3,
 } ohmd_string_value;
 
 /** A collection of string descriptions, used for getting strings with ohmd_gets(). */

--- a/src/openhmd.c
+++ b/src/openhmd.c
@@ -161,6 +161,8 @@ OHMD_APIENTRYDLL const char* OHMD_APIENTRY ohmd_list_gets(ohmd_context* ctx, int
 		return ctx->list.devices[index].product;
 	case OHMD_PATH:
 		return ctx->list.devices[index].path;
+	case OHMD_DRIVER:
+		return ctx->list.devices[index].driver;
 	default:
 		return NULL;
 	}


### PR DESCRIPTION
This adds the `OHMD_DRIVER` to `ohmd_list_gets` to be more consistent with the `ohmd_device_desc` struct. This also displays that driver in the simple example. Reason I added this was for clarity; I was running the example on a laptop with no devices connected and was surprised to see devices connected. It is somewhat obvious that it is the dummy driver (and it says null device) but I think this improves clarity for newcomers and people possibly testing multiple devices or adding new drivers etc.