### PR TITLE
Print available drivers

### DIFF
--- a/examples/simple/simple.c
+++ b/examples/simple/simple.c
@@ -54,6 +54,10 @@ int main(int argc, char** argv)
 
 	ohmd_context* ctx = ohmd_ctx_create();
 
+	printf("\n");
+	ohmd_print_available_drivers(ctx);
+	printf("\n");
+
 	// Probe for devices
 	int num_devices = ohmd_ctx_probe(ctx);
 	if(num_devices < 0){

--- a/include/openhmd.h
+++ b/include/openhmd.h
@@ -478,6 +478,13 @@ OHMD_APIENTRYDLL ohmd_status OHMD_APIENTRY ohmd_require_version(int major, int m
  **/
 OHMD_APIENTRYDLL void OHMD_APIENTRY ohmd_sleep(double time);
 
+/**
+ * Print a list of drivers the library was built with.
+ *
+ * @param ctx A pointer to a valid ohmd_context.
+ */
+OHMD_APIENTRYDLL void OHMD_APIENTRY ohmd_print_available_drivers(ohmd_context* ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/drv_3glasses/xgvr.c
+++ b/src/drv_3glasses/xgvr.c
@@ -274,7 +274,7 @@ static void _get_device_list(ohmd_driver* driver, ohmd_device_list* list)
             desc->device_flags = OHMD_DEVICE_FLAGS_ROTATIONAL_TRACKING;
 
             strcpy(desc->path, cur_dev->path);
-            desc->driver_ptr = driver;
+            desc->driver = driver;
             cur_dev = cur_dev->next;
         }
 

--- a/src/drv_3glasses/xgvr.c
+++ b/src/drv_3glasses/xgvr.c
@@ -265,7 +265,6 @@ static void _get_device_list(ohmd_driver* driver, ohmd_device_list* list)
         while (cur_dev) {
             ohmd_device_desc* desc = &list->devices[list->num_devices++];
 
-            strcpy(desc->driver, "OpenHMD 3Glasses Driver");
             strcpy(desc->vendor, "3Glasses");
             strcpy(desc->product, platform_sku[i].desc);
 
@@ -296,6 +295,7 @@ ohmd_driver* ohmd_create_xgvr_drv(ohmd_context* ctx)
     if (drv == NULL)
         return NULL;
 
+    strcpy(drv->name, "OpenHMD 3Glasses Driver");
     drv->get_device_list = _get_device_list;
     drv->open_device = _open_device;
     drv->destroy = _destroy_driver;

--- a/src/drv_android/android.c
+++ b/src/drv_android/android.c
@@ -233,7 +233,6 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 {
 	ohmd_device_desc* desc = &list->devices[list->num_devices++];
 
-	strcpy(desc->driver, "OpenHMD Generic Android Driver");
 	strcpy(desc->vendor, "OpenHMD");
 	strcpy(desc->product, "Android Device");
 
@@ -257,6 +256,7 @@ ohmd_driver* ohmd_create_android_drv(ohmd_context* ctx)
 	if(!drv)
 		return NULL;
 
+	strcpy(drv->name, "OpenHMD Generic Android Driver");
 	drv->get_device_list = get_device_list;
 	drv->open_device = open_device;
 	drv->destroy = destroy_driver;

--- a/src/drv_android/android.c
+++ b/src/drv_android/android.c
@@ -241,7 +241,7 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 	desc->device_class = OHMD_DEVICE_CLASS_HMD;
 	desc->device_flags = OHMD_DEVICE_FLAGS_ROTATIONAL_TRACKING;
 
-	desc->driver_ptr = driver;
+	desc->driver = driver;
 }
 
 static void destroy_driver(ohmd_driver* drv)

--- a/src/drv_deepoon/deepoon.c
+++ b/src/drv_deepoon/deepoon.c
@@ -283,7 +283,6 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 
 			ohmd_device_desc* desc = &list->devices[list->num_devices++];
 
-			strcpy(desc->driver, "Deepoon Driver");
 			strcpy(desc->vendor, "Deepoon");
 			strcpy(desc->product, "Deepoon E2");
 
@@ -313,6 +312,7 @@ ohmd_driver* ohmd_create_deepoon_drv(ohmd_context* ctx)
 	if(drv == NULL)
 		return NULL;
 
+	strcpy(drv->name, "Deepoon Driver");
 	drv->get_device_list = get_device_list;
 	drv->open_device = open_device;
 	drv->ctx = ctx;

--- a/src/drv_deepoon/deepoon.c
+++ b/src/drv_deepoon/deepoon.c
@@ -291,7 +291,7 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 
 			desc->revision = 0;
 			strcpy(desc->path, cur_dev->path);
-			desc->driver_ptr = driver;
+			desc->driver = driver;
 		}
 		cur_dev = cur_dev->next;
 	}

--- a/src/drv_deepoon/deepoon.c
+++ b/src/drv_deepoon/deepoon.c
@@ -312,7 +312,7 @@ ohmd_driver* ohmd_create_deepoon_drv(ohmd_context* ctx)
 	if(drv == NULL)
 		return NULL;
 
-	strcpy(drv->name, "Deepoon Driver");
+	strcpy(drv->name, "OpenHMD Deepoon Driver");
 	drv->get_device_list = get_device_list;
 	drv->open_device = open_device;
 	drv->ctx = ctx;

--- a/src/drv_dummy/dummy.c
+++ b/src/drv_dummy/dummy.c
@@ -128,7 +128,7 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 
 	strcpy(desc->path, "(none)");
 
-	desc->driver_ptr = driver;
+	desc->driver = driver;
 
 	desc->device_flags = OHMD_DEVICE_FLAGS_NULL_DEVICE | OHMD_DEVICE_FLAGS_ROTATIONAL_TRACKING;
 	desc->device_class = OHMD_DEVICE_CLASS_HMD;
@@ -144,7 +144,7 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 
 	strcpy(desc->path, "(none)");
 
-	desc->driver_ptr = driver;
+	desc->driver = driver;
 
 	desc->device_flags = OHMD_DEVICE_FLAGS_NULL_DEVICE | 
 		OHMD_DEVICE_FLAGS_POSITIONAL_TRACKING | 
@@ -164,7 +164,7 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 
 	strcpy(desc->path, "(none)");
 
-	desc->driver_ptr = driver;
+	desc->driver = driver;
 
 	desc->device_flags = OHMD_DEVICE_FLAGS_NULL_DEVICE | 
 		OHMD_DEVICE_FLAGS_POSITIONAL_TRACKING | 

--- a/src/drv_dummy/dummy.c
+++ b/src/drv_dummy/dummy.c
@@ -123,7 +123,6 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 
 	desc = &list->devices[list->num_devices++];
 
-	strcpy(desc->driver, "OpenHMD Null Driver");
 	strcpy(desc->vendor, "OpenHMD");
 	strcpy(desc->product, "HMD Null Device");
 
@@ -140,7 +139,6 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 	
 	desc = &list->devices[list->num_devices++];
 
-	strcpy(desc->driver, "OpenHMD Null Driver");
 	strcpy(desc->vendor, "OpenHMD");
 	strcpy(desc->product, "Left Controller Null Device");
 
@@ -161,7 +159,6 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 	
 	desc = &list->devices[list->num_devices++];
 
-	strcpy(desc->driver, "OpenHMD Null Driver");
 	strcpy(desc->vendor, "OpenHMD");
 	strcpy(desc->product, "Right Controller Null Device");
 
@@ -191,6 +188,7 @@ ohmd_driver* ohmd_create_dummy_drv(ohmd_context* ctx)
 	if(!drv)
 		return NULL;
 
+	strcpy(drv->name, "OpenHMD Null Driver");
 	drv->get_device_list = get_device_list;
 	drv->open_device = open_device;
 	drv->get_device_list = get_device_list;

--- a/src/drv_external/external.c
+++ b/src/drv_external/external.c
@@ -116,7 +116,7 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 	desc->device_class = OHMD_DEVICE_CLASS_HMD;
 	desc->device_flags = OHMD_DEVICE_FLAGS_ROTATIONAL_TRACKING | OHMD_DEVICE_FLAGS_POSITIONAL_TRACKING;
 
-	desc->driver_ptr = driver;
+	desc->driver = driver;
 }
 
 static void destroy_driver(ohmd_driver* drv)

--- a/src/drv_external/external.c
+++ b/src/drv_external/external.c
@@ -108,7 +108,6 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 {
 	ohmd_device_desc* desc = &list->devices[list->num_devices++];
 
-	strcpy(desc->driver, "OpenHMD Generic External Driver");
 	strcpy(desc->vendor, "OpenHMD");
 	strcpy(desc->product, "External Device");
 
@@ -132,6 +131,7 @@ ohmd_driver* ohmd_create_external_drv(ohmd_context* ctx)
 	if(!drv)
 		return NULL;
 
+	strcpy(drv->name, "OpenHMD Generic External Driver");
 	drv->get_device_list = get_device_list;
 	drv->open_device = open_device;
 	drv->destroy = destroy_driver;

--- a/src/drv_htc_vive/vive.c
+++ b/src/drv_htc_vive/vive.c
@@ -683,7 +683,6 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 	while (cur_dev) {
 		ohmd_device_desc* desc = &list->devices[list->num_devices++];
 
-		strcpy(desc->driver, "OpenHMD HTC Vive Driver");
 		strcpy(desc->vendor, "HTC/Valve");
 		strcpy(desc->product, "HTC Vive");
 
@@ -715,6 +714,7 @@ ohmd_driver* ohmd_create_htc_vive_drv(ohmd_context* ctx)
 	if(!drv)
 		return NULL;
 
+	strcpy(drv->name, "OpenHMD HTC Vive Driver");
 	drv->get_device_list = get_device_list;
 	drv->open_device = open_device;
 	drv->destroy = destroy_driver;

--- a/src/drv_htc_vive/vive.c
+++ b/src/drv_htc_vive/vive.c
@@ -690,7 +690,7 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 
 		snprintf(desc->path, OHMD_STR_SIZE, "%d", idx);
 
-		desc->driver_ptr = driver;
+		desc->driver = driver;
 		desc->device_class = OHMD_DEVICE_CLASS_HMD;
 		desc->device_flags = OHMD_DEVICE_FLAGS_ROTATIONAL_TRACKING;
 

--- a/src/drv_nolo/nolo.c
+++ b/src/drv_nolo/nolo.c
@@ -369,7 +369,6 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 		while (cur_dev && is_nolo_device(cur_dev)) {
 			ohmd_device_desc* desc = &list->devices[list->num_devices++];
 
-			strcpy(desc->driver, "OpenHMD NOLO VR CV1 driver");
 			strcpy(desc->vendor, "LYRobotix");
 			strcpy(desc->product, rd[i].name);
 
@@ -386,7 +385,6 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 			//Controller 0
 			desc = &list->devices[list->num_devices++];
 
-			strcpy(desc->driver, "OpenHMD NOLO VR CV1 driver");
 			strcpy(desc->vendor, "LYRobotix");
 			strcpy(desc->product, "NOLO CV1: Controller 0");
 
@@ -405,7 +403,6 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 			// Controller 1
 			desc = &list->devices[list->num_devices++];
 
-			strcpy(desc->driver, "OpenHMD NOLO VR CV1 driver");
 			strcpy(desc->vendor, "LYRobotix");
 			strcpy(desc->product, "NOLO CV1: Controller 1");
 
@@ -440,6 +437,7 @@ ohmd_driver* ohmd_create_nolo_drv(ohmd_context* ctx)
 	if(drv == NULL)
 		return NULL;
 
+	strcpy(drv->name, "OpenHMD NOLO VR CV1 driver");
 	drv->get_device_list = get_device_list;
 	drv->open_device = open_device;
 	drv->destroy = destroy_driver;

--- a/src/drv_nolo/nolo.c
+++ b/src/drv_nolo/nolo.c
@@ -379,7 +379,7 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 			desc->device_flags = OHMD_DEVICE_FLAGS_POSITIONAL_TRACKING | OHMD_DEVICE_FLAGS_ROTATIONAL_TRACKING;
 			desc->device_class = OHMD_DEVICE_CLASS_HMD;
 
-			desc->driver_ptr = driver;
+			desc->driver = driver;
 			desc->id = id++;
 
 			//Controller 0
@@ -397,7 +397,7 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 
 			desc->device_class = OHMD_DEVICE_CLASS_CONTROLLER;
 
-			desc->driver_ptr = driver;
+			desc->driver = driver;
 			desc->id = id++;
 
 			// Controller 1
@@ -415,7 +415,7 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 
 			desc->device_class = OHMD_DEVICE_CLASS_CONTROLLER;
 
-			desc->driver_ptr = driver;
+			desc->driver = driver;
 			desc->id = id++;
 
 			cur_dev = cur_dev->next;

--- a/src/drv_oculus_rift/rift.c
+++ b/src/drv_oculus_rift/rift.c
@@ -1083,7 +1083,6 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 				int id = 0;
 				ohmd_device_desc* desc = &list->devices[list->num_devices++];
 
-				strcpy(desc->driver, "OpenHMD Rift Driver");
 				strcpy(desc->vendor, "Oculus VR, Inc.");
 				strcpy(desc->product, rd[i].name);
 
@@ -1103,7 +1102,6 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 					desc = &list->devices[list->num_devices++];
 					desc->revision = rd[i].rev;
 
-					strcpy(desc->driver, "OpenHMD Rift Driver");
 					strcpy(desc->vendor, "Oculus VR, Inc.");
 					sprintf(desc->product, "%s: Right Controller", rd[i].name);
 
@@ -1122,7 +1120,6 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 					desc = &list->devices[list->num_devices++];
 					desc->revision = rd[i].rev;
 
-					strcpy(desc->driver, "OpenHMD Rift Driver");
 					strcpy(desc->vendor, "Oculus VR, Inc.");
 					sprintf(desc->product, "%s: Left Controller", rd[i].name);
 
@@ -1162,6 +1159,7 @@ ohmd_driver* ohmd_create_oculus_rift_drv(ohmd_context* ctx)
 
 	ohmd_toggle_ovr_service(0); //disable OVRService if running
 
+	strcpy(drv->name, "OpenHMD Rift Driver");
 	drv->get_device_list = get_device_list;
 	drv->open_device = open_device;
 	drv->destroy = destroy_driver;

--- a/src/drv_oculus_rift/rift.c
+++ b/src/drv_oculus_rift/rift.c
@@ -1093,7 +1093,7 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 
 				strcpy(desc->path, cur_dev->path);
 
-				desc->driver_ptr = driver;
+				desc->driver = driver;
 				desc->id = id++;
 
 				/* For CV1, publish touch controllers */
@@ -1113,7 +1113,7 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 						OHMD_DEVICE_FLAGS_RIGHT_CONTROLLER;
 
 					desc->device_class = OHMD_DEVICE_CLASS_CONTROLLER;
-					desc->driver_ptr = driver;
+					desc->driver = driver;
 					desc->id = id++;
 
 					// Controller 1 (left)
@@ -1131,7 +1131,7 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 						OHMD_DEVICE_FLAGS_LEFT_CONTROLLER;
 
 					desc->device_class = OHMD_DEVICE_CLASS_CONTROLLER;
-					desc->driver_ptr = driver;
+					desc->driver = driver;
 					desc->id = id++;
 				}
 			}

--- a/src/drv_psvr/psvr.c
+++ b/src/drv_psvr/psvr.c
@@ -345,7 +345,7 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 
 			snprintf(desc->path, OHMD_STR_SIZE, "%d", idx);
 
-			desc->driver_ptr = driver;
+			desc->driver = driver;
 
 			desc->device_class = OHMD_DEVICE_CLASS_HMD;
 			desc->device_flags = OHMD_DEVICE_FLAGS_ROTATIONAL_TRACKING;

--- a/src/drv_psvr/psvr.c
+++ b/src/drv_psvr/psvr.c
@@ -338,7 +338,6 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 		if (cur_dev->interface_number == 4) {
 			desc = &list->devices[list->num_devices++];
 
-			strcpy(desc->driver, "OpenHMD Sony PSVR Driver");
 			strcpy(desc->vendor, "Sony");
 			strcpy(desc->product, "PSVR");
 
@@ -373,6 +372,7 @@ ohmd_driver* ohmd_create_psvr_drv(ohmd_context* ctx)
 	if(!drv)
 		return NULL;
 
+	strcpy(drv->name, "OpenHMD Sony PSVR Driver");
 	drv->get_device_list = get_device_list;
 	drv->open_device = open_device;
 	drv->destroy = destroy_driver;

--- a/src/drv_vrtek/vrtek.c
+++ b/src/drv_vrtek/vrtek.c
@@ -635,7 +635,6 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
                         wcscmp(cur_dev->product_string, L"HID")==0) {
             ohmd_device_desc* desc = &list->devices[list->num_devices++];
 
-            strcpy(desc->driver, "OpenHMD VR-Tek Driver");
             strcpy(desc->vendor, "VR-Tek");
             strcpy(desc->product, "VR-Tek WVR");
 
@@ -664,6 +663,7 @@ ohmd_driver* ohmd_create_vrtek_drv(ohmd_context* ctx)
     if (drv == NULL)
         return NULL;
 
+    strcpy(drv->name, "OpenHMD VR-Tek Driver");
     drv->get_device_list = get_device_list;
     drv->open_device = open_device;
     drv->destroy = destroy_driver;

--- a/src/drv_vrtek/vrtek.c
+++ b/src/drv_vrtek/vrtek.c
@@ -642,7 +642,7 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
             desc->device_flags = OHMD_DEVICE_FLAGS_ROTATIONAL_TRACKING;
 
             strcpy(desc->path, cur_dev->path);
-            desc->driver_ptr = driver;
+            desc->driver = driver;
         }
         cur_dev = cur_dev->next;
     }

--- a/src/drv_wmr/wmr.c
+++ b/src/drv_wmr/wmr.c
@@ -476,7 +476,7 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 
 		snprintf(desc->path, OHMD_STR_SIZE, "%d", idx);
 
-		desc->driver_ptr = driver;
+		desc->driver = driver;
 
 		desc->device_class = OHMD_DEVICE_CLASS_HMD;
 		desc->device_flags = OHMD_DEVICE_FLAGS_ROTATIONAL_TRACKING;

--- a/src/drv_wmr/wmr.c
+++ b/src/drv_wmr/wmr.c
@@ -469,7 +469,6 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 	while (cur_dev) {
 		ohmd_device_desc* desc = &list->devices[list->num_devices++];
 
-		strcpy(desc->driver, "OpenHMD Windows Mixed Reality Driver");
 		strcpy(desc->vendor, "Microsoft");
 		strcpy(desc->product, "HoloLens Sensors");
 
@@ -502,6 +501,7 @@ ohmd_driver* ohmd_create_wmr_drv(ohmd_context* ctx)
 	if(!drv)
 		return NULL;
 
+	strcpy(drv->name, "OpenHMD Windows Mixed Reality Driver");
 	drv->get_device_list = get_device_list;
 	drv->open_device = open_device;
 	drv->destroy = destroy_driver;

--- a/src/openhmd.c
+++ b/src/openhmd.c
@@ -221,7 +221,7 @@ OHMD_APIENTRYDLL ohmd_device* OHMD_APIENTRY ohmd_list_open_device_s(ohmd_context
 	if(index >= 0 && index < ctx->list.num_devices){
 
 		ohmd_device_desc* desc = &ctx->list.devices[index];
-		ohmd_driver* driver = (ohmd_driver*)desc->driver_ptr;
+		ohmd_driver* driver = (ohmd_driver*)desc->driver;
 		ohmd_device* device = driver->open_device(driver, desc);
 
 		if (device == NULL) {

--- a/src/openhmd.c
+++ b/src/openhmd.c
@@ -645,3 +645,11 @@ ohmd_status ohmd_require_version(int major, int minor, int patch)
 
 	return OHMD_S_OK;
 }
+
+void ohmd_print_available_drivers(ohmd_context* ctx)
+{
+	printf("available drivers:\n");
+	for (int i = 0; i < ctx->num_drivers; ++i) {
+		printf("  %s\n", ctx->drivers[i]->name);
+	}
+}

--- a/src/openhmdi.h
+++ b/src/openhmdi.h
@@ -34,7 +34,6 @@
 typedef struct ohmd_driver ohmd_driver;
 
 typedef struct {
-	char driver[OHMD_STR_SIZE];
 	char vendor[OHMD_STR_SIZE];
 	char product[OHMD_STR_SIZE];
 	char path[OHMD_STR_SIZE];
@@ -51,6 +50,7 @@ typedef struct {
 } ohmd_device_list;
 
 struct ohmd_driver {
+	char name[OHMD_STR_SIZE];
 	void (*get_device_list)(ohmd_driver* driver, ohmd_device_list* list);
 	ohmd_device* (*open_device)(ohmd_driver* driver, ohmd_device_desc* desc);
 	void (*destroy)(ohmd_driver* driver);

--- a/src/openhmdi.h
+++ b/src/openhmdi.h
@@ -41,7 +41,7 @@ typedef struct {
 	int id;
 	ohmd_device_flags device_flags;
 	ohmd_device_class device_class;
-	ohmd_driver* driver_ptr;
+	ohmd_driver* driver;
 } ohmd_device_desc;
 
 typedef struct {


### PR DESCRIPTION
This is an attempt to address #241. A few things here:

I moved `ohmd_device_desc.driver` to `ohmd_driver.name`, which I feel makes more semantic sense than having it on every device. This is actually enough I think for users to be able to print a list of compiled drivers, as you could now iterate over the drivers in `ohmd_ctx` and print their names. You can still get the driver name from a device through the driver pointer.

Next, I renamed `ohmd_device_desc.driver_ptr` to `ohmd_device_desc.driver` as there is no longer a naming conflict. It is not my intention to break any APIs here so I guess this is optional.

Then, I added a function `ohmd_print_available_drivers` that prints the drivers in `ctx`. I figured this was more convenient that returning a `char**`, because at that point a user could just do it themselves via the information in `ctx`. I also call this function from the simple example, so that we get:

```
OpenHMD version: 0.3.0

available drivers:
  OpenHMD Rift Driver
  OpenHMD Deepoon Driver
  OpenHMD HTC Vive Driver
  OpenHMD Windows Mixed Reality Driver
  OpenHMD Sony PSVR Driver
  OpenHMD NOLO VR CV1 driver
  OpenHMD 3Glasses Driver
  OpenHMD VR-Tek Driver
  OpenHMD Generic External Driver
  OpenHMD Null Driver

num devices: 4

<cut here>
```

Lastly as you can see in the output I renamed the 'Deepon Driver' to 'OpenHMD Depoon Driver' to be more consistent, not sure if there was a reason for that or not.

Apologies in advance if I violated the conventions of the library, and I am more of a Ruby programmer than a C programmer ;)  Feedback welcome.