### PR TITLE
meson: Declare the openhmd_dep dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -237,6 +237,11 @@ pkg.generate(
 )
 install_headers('include/openhmd.h', subdir: 'openhmd')
 
+# Declare openhmd as a dependency so it can be used
+# as a meson subproject
+openhmd_dep = declare_dependency(
+  include_directories: include_directories('./include'),
+  link_with : openhmd_lib)
 
 #
 # Unit tests


### PR DESCRIPTION
Allow the use of OpenHMD as a subproject by declaring a meson
dependency in meson.build

By publishing a dependency variable, other projects that use meson can pull in OpenHMD as a wrapped subproject.