### PR TITLE
Updated hidapi revision to make it build on Mingw-w64

### DIFF
--- a/subprojects/hidapi.wrap
+++ b/subprojects/hidapi.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = hidapi
 url = https://github.com/OpenHMD/hidapi
-revision = b245d332914021c420001292ddea1769eff17f6d
+revision = f19cb5e6ec30882b1367058e73a413b0b45636a2


### PR DESCRIPTION
Updated hidapi.wrap to use revision [f19cb5e6ec30882b1367058e73a413b0b45636a2](https://github.com/OpenHMD/hidapi/commit/f19cb5e6ec30882b1367058e73a413b0b45636a2). This makes it easier to build master with Mingw-w64.