### PR TITLE
Fix WMR driver build via CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ if(OPENHMD_DRIVER_WMR)
 	set(openhmd_source_files ${openhmd_source_files}
 	${CMAKE_CURRENT_LIST_DIR}/src/drv_wmr/wmr.c
 	${CMAKE_CURRENT_LIST_DIR}/src/drv_wmr/packet.c
+	${CMAKE_CURRENT_LIST_DIR}/src/ext_deps/nxjson.c
 	)
 	add_definitions(-DDRIVER_WMR)
 


### PR DESCRIPTION
`nxjson` is missing when only building the Windows Mixed Reality driver via CMake. This pull request fixes this issue.