### PR TITLE
Opengl example improvements

### DIFF
--- a/examples/opengl/main.c
+++ b/examples/opengl/main.c
@@ -63,9 +63,25 @@ GLuint gen_cubes()
 	}
 
 	// draw floor
-	glColor4f(0, 1.0f, .25f, .25f);
-	glTranslatef(0, -2.5f, 0);
-	draw_cube();
+	const int SIZE = 9;
+
+	for (int y=-SIZE; y <= SIZE; y++) {
+		for (int x=-SIZE; x <= SIZE; x++) {
+			glPushMatrix();
+			glTranslatef(x, -2.5f, y);
+			/* Shrink cubes slightly to avoid surfaces fighting */
+			glScalef(0.999, 1.0, 0.999);
+
+			if ((x&1) == (y&1)) {
+				glColor4f(0, 1.0f, .25f, .25f);
+			} else {
+				glColor4f(0, 0.0f, .5f, 1.0f);
+			}
+
+			draw_cube();
+			glPopMatrix();
+		}
+	}
 
 	glEndList();
 

--- a/examples/opengl/main.c
+++ b/examples/opengl/main.c
@@ -253,6 +253,7 @@ int main(int argc, char** argv)
 						printf("lens separation: %04f\n", sep);
 						printf("IPD: %0.4f\n", ipd);
 						printf("warp_scale: %0.4f\r\n", warp_scale);
+						printf("warp_adj: %0.4f => Actual warp_scale = %0.4f\r\n", warp_adj, warp_adj * warp_scale);
 						printf("distortion coeffs: [%0.4f, %0.4f, %0.4f, %0.4f]\n", distortion_coeffs[0], distortion_coeffs[1], distortion_coeffs[2], distortion_coeffs[3]);
 						printf("aberration coeffs: [%0.4f, %0.4f, %0.4f]\n", aberr_scale[0], aberr_scale[1], aberr_scale[2]);
 						printf("left_lens_center: [%0.4f, %0.4f]\n", left_lens_center[0], left_lens_center[1]);


### PR DESCRIPTION
Some improvements to the OpenGL example that I made while developing the Rift S driver - primarily the addition of a checkerboard floor that makes correct/incorrect distortion really easy to see.