### PR TITLE
hide internal symbols

### DIFF
--- a/src/drv_3glasses/xgvr.c
+++ b/src/drv_3glasses/xgvr.c
@@ -42,7 +42,7 @@ typedef struct {
     char *desc;
     int sku;
 } xgvr_platform_sku_t;
-xgvr_platform_sku_t platform_sku[] = {
+static const xgvr_platform_sku_t platform_sku[] = {
     {
         0x2b1c, 0x0200, "3Glasses-D3V1", PLATFORM_SKU_D3V1_M41V2,
     },

--- a/src/drv_htc_vive/packet.c
+++ b/src/drv_htc_vive/packet.c
@@ -70,7 +70,7 @@ bool vive_decode_sensor_packet(vive_headset_imu_packet* pkt,
 }
 
 //Trim function for removing tabs and spaces from string buffers
-void trim(const char* src, char* buff, const unsigned int sizeBuff)
+static void trim(const char* src, char* buff, const unsigned int sizeBuff)
 {
 	if(sizeBuff < 1)
 		return;
@@ -86,7 +86,7 @@ void trim(const char* src, char* buff, const unsigned int sizeBuff)
 	buff[i] = '\0';
 }
 
-void get_vec3f_from_json(const nx_json* json, const char* name, vec3f* result)
+static void get_vec3f_from_json(const nx_json* json, const char* name, vec3f* result)
 {
 	const nx_json* acc_bias_arr = nx_json_get(json, name);
 
@@ -96,7 +96,7 @@ void get_vec3f_from_json(const nx_json* json, const char* name, vec3f* result)
 	}
 }
 
-void print_vec3f(const char* title, vec3f *vec)
+static void print_vec3f(const char* title, vec3f *vec)
 {
 	LOGI("%s = %f %f %f\n", title, vec->x, vec->y, vec->z);
 }

--- a/src/drv_htc_vive/vive.c
+++ b/src/drv_htc_vive/vive.c
@@ -56,9 +56,9 @@ typedef struct {
 
 } vive_priv;
 
-void vec3f_from_vive_vec_accel(const vive_imu_config* config,
-                               const int16_t* smp,
-                               vec3f* out)
+static void vec3f_from_vive_vec_accel(const vive_imu_config* config,
+                                      const int16_t* smp,
+                                      vec3f* out)
 {
 	float range = config->acc_range / 32768.0f;
 	out->x = range * config->acc_scale.x * (float) smp[0] - config->acc_bias.x;
@@ -66,9 +66,9 @@ void vec3f_from_vive_vec_accel(const vive_imu_config* config,
 	out->z = range * config->acc_scale.z * (float) smp[2] - config->acc_bias.z;
 }
 
-void vec3f_from_vive_vec_gyro(const vive_imu_config* config,
-                              const int16_t* smp,
-                              vec3f* out)
+static void vec3f_from_vive_vec_gyro(const vive_imu_config* config,
+                                     const int16_t* smp,
+                                     vec3f* out)
 {
 	float range = config->gyro_range / 32768.0f;
 	out->x = range * config->gyro_scale.x * (float)smp[0] - config->gyro_bias.x;
@@ -92,8 +92,8 @@ static bool process_error(vive_priv* priv)
 	return false;
 }
 
-vive_headset_imu_sample* get_next_sample(vive_headset_imu_packet* pkt,
-                                         int last_seq)
+static vive_headset_imu_sample* get_next_sample(vive_headset_imu_packet* pkt,
+                                                int last_seq)
 {
 	int diff[3];
 
@@ -336,7 +336,7 @@ static hid_device* open_device_idx(int manufacturer, int product, int iface,
 	return ret;
 }
 
-int vive_read_firmware(hid_device* device)
+static int vive_read_firmware(hid_device* device)
 {
 	vive_firmware_version_packet packet = {
 		.id = VIVE_FIRMWARE_VERSION_PACKET_ID,
@@ -366,7 +366,7 @@ int vive_read_firmware(hid_device* device)
 	return 0;
 }
 
-int vive_read_config(vive_priv* priv)
+static int vive_read_config(vive_priv* priv)
 {
 	vive_config_start_packet start_packet = {
 		.id = VIVE_CONFIG_START_PACKET_ID,
@@ -415,7 +415,7 @@ int vive_read_config(vive_priv* priv)
 
 #define OHMD_GRAVITY_EARTH 9.80665 // m/s²
 
-int vive_get_range_packet(vive_priv* priv)
+static int vive_get_range_packet(vive_priv* priv)
 {
 	int ret;
 

--- a/src/drv_nolo/nolo.c
+++ b/src/drv_nolo/nolo.c
@@ -28,14 +28,14 @@ static drv_priv* drv_priv_get(ohmd_device* device)
 	return (drv_priv*)device;
 }
 
-void accel_from_nolo_vec(const int16_t* smp, vec3f* out_vec)
+static void accel_from_nolo_vec(const int16_t* smp, vec3f* out_vec)
 {
 	out_vec->x = (float)smp[0];
 	out_vec->y = (float)smp[1];
 	out_vec->z = -(float)smp[2];
 }
 
-void gyro_from_nolo_vec(const int16_t* smp, vec3f* out_vec)
+static void gyro_from_nolo_vec(const int16_t* smp, vec3f* out_vec)
 {
 	out_vec->x = (float)smp[0];
 	out_vec->y = (float)smp[1];
@@ -196,7 +196,7 @@ static void close_device(ohmd_device* device)
 	free(priv);
 }
 
-void push_device(devices_t * head, drv_nolo* val) {
+static void push_device(devices_t * head, drv_nolo* val) {
 	devices_t* current = head;
 
 	if (!nolo_devices)
@@ -337,7 +337,7 @@ typedef struct {
 	int product;
 } nolo_verions;
 
-int is_nolo_device(struct hid_device_info* device)
+static int is_nolo_device(struct hid_device_info* device)
 {
 	if (wcscmp(device->manufacturer_string, L"LYRobotix") != 0) {
 		return 0;

--- a/src/drv_nolo/packet.c
+++ b/src/drv_nolo/packet.c
@@ -109,7 +109,7 @@ void nolo_decode_orientation(const unsigned char* data, nolo_sample* smp)
 	}
 }
 
-void nolo_decode_controller_orientation(const unsigned char* data, nolo_sample* smp)
+static void nolo_decode_controller_orientation(const unsigned char* data, nolo_sample* smp)
 {	
 	// gyro
 	for(int i = 0; i < 3; i++){

--- a/src/drv_psvr/psvr.c
+++ b/src/drv_psvr/psvr.c
@@ -39,14 +39,14 @@ typedef struct {
 
 } psvr_priv;
 
-void accel_from_psvr_vec(const int16_t* smp, vec3f* out_vec)
+static void accel_from_psvr_vec(const int16_t* smp, vec3f* out_vec)
 {
 	out_vec->x = (float)smp[1] *  (9.81 / 16384);
 	out_vec->y = (float)smp[0] *  (9.81 / 16384);
 	out_vec->z = (float)smp[2] * -(9.81 / 16384);
 }
 
-void gyro_from_psvr_vec(const int16_t* smp, vec3f* out_vec)
+static void gyro_from_psvr_vec(const int16_t* smp, vec3f* out_vec)
 {
 	out_vec->x = (float)smp[1] * 0.00105f;
 	out_vec->y = (float)smp[0] * 0.00105f;

--- a/src/openhmd.c
+++ b/src/openhmd.c
@@ -392,7 +392,7 @@ OHMD_APIENTRYDLL int OHMD_APIENTRY ohmd_device_getf(ohmd_device* device, ohmd_fl
 	return ret;
 }
 
-int ohmd_device_setf_unp(ohmd_device* device, ohmd_float_value type, const float* in)
+static int ohmd_device_setf_unp(ohmd_device* device, ohmd_float_value type, const float* in)
 {
 	switch(type){
 	case OHMD_EYE_IPD:
@@ -490,7 +490,7 @@ OHMD_APIENTRYDLL int OHMD_APIENTRY ohmd_device_seti(ohmd_device* device, ohmd_in
 }
 
 
-int ohmd_device_set_data_unp(ohmd_device* device, ohmd_data_value type, const void* in)
+static int ohmd_device_set_data_unp(ohmd_device* device, ohmd_data_value type, const void* in)
 {
     switch(type){
     case OHMD_DRIVER_DATA:


### PR DESCRIPTION
Use the static keyword to hide internal functions and variables.