### PR TITLE
Rifts fix shutdown crashes

### DIFF
--- a/src/drv_oculus_rift/rift.c
+++ b/src/drv_oculus_rift/rift.c
@@ -99,8 +99,10 @@ static rift_hmd_t *find_hmd(char *hid_path)
 	device_list_t* current = rift_hmds;
 
 	while (current != NULL) {
-		if (strcmp(current->path, hid_path)==0)
+		if (strcmp(current->path, hid_path)==0) {
+			current->hmd->use_count++;
 			return current->hmd;
+		}
 		current = current->next;
 	}
 	return NULL;
@@ -1038,6 +1040,7 @@ static ohmd_device* open_device(ohmd_driver* driver, ohmd_device_desc* desc)
 		dev = &hmd->touch_dev[1].base;
 	else {
 		LOGE ("Invalid device description passed to open_device()");
+		release_hmd(hmd);
 		return NULL;
 	}
 

--- a/src/drv_oculus_rift_s/rift-s.c
+++ b/src/drv_oculus_rift_s/rift-s.c
@@ -55,8 +55,10 @@ static rift_s_hmd_t *find_hmd(char *hid_path)
 	device_list_t* current = rift_hmds;
 
 	while (current != NULL) {
-		if (strcmp(current->path, hid_path)==0)
+		if (strcmp(current->path, hid_path)==0) {
+			current->hmd->use_count++;
 			return current->hmd;
+		}
 		current = current->next;
 	}
 	return NULL;
@@ -597,6 +599,7 @@ static ohmd_device* open_device(ohmd_driver* driver, ohmd_device_desc* desc)
 	}
 	else {
 		LOGE ("Invalid device description passed to open_device()");
+		release_hmd (hmd);
 		return NULL;
 	}
 


### PR DESCRIPTION
Fix crashes on closing devices after opening multiple ones by tracking the shared state counter correctly.