### PR TITLE
[wmr] Fix type of wmr_config_header field

### DIFF
--- a/src/drv_wmr/wmr.h
+++ b/src/drv_wmr/wmr.h
@@ -38,7 +38,8 @@ static const unsigned char hololens_sensors_imu_on[64] = {
 };
 
 typedef struct {
-        uint32_t json_start;
+        uint16_t json_start;
+        uint16_t header_version;
         uint32_t json_size;
         char manufacturer[0x40];
         char device[0x40];


### PR DESCRIPTION
The calibration header contains a 16 bit version field, which we are
incorrectly parsing as part of the json_start field. Presumably this has
gone unnoticed because the header version field is always set to 0 in
practice.

Change type of json_start field from uint32_t to uint16_t, and insert a
new field uint16_t header_version.