### PR TITLE
Include openhmd.h and openhmd.lib so you can download this as an SDK

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ build_script:
   - cmd: echo Building on %arch% with %compiler%
   - cmd: meson --backend=ninja builddir -Dexamples=simple
   - cmd: ninja -C builddir install
-  - cmd: 7z a openhmd.zip c:\bin\*.dll c:\bin\*.exe
+  - cmd: 7z a openhmd.zip c:\include\openhmd\openhmd.h c:\lib\openhmd.lib c:\bin\*.dll c:\bin\*.exe
 
 artifacts:
   - path: openhmd.zip


### PR DESCRIPTION
Just as a suggestion for Windows but if you guys want to follow suit this would be good to do for Linux and Mac release packages too.

Add in the openhmd.h and openhmd.lib files so poor people like me can include OpenHMD in their projects without having to compile it themselves. 