### PR TITLE
meson: If doing a static build, export that information.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -56,6 +56,8 @@ else
 	sources += 'src/platform-posix.c'
 endif
 c_args = []
+publish_c_args = []
+
 if get_option('default_library') == 'shared'
 	if host_machine.system() == 'windows'
 		c_args += '-DDLL_EXPORT'
@@ -65,6 +67,7 @@ if get_option('default_library') == 'shared'
 else
 	if host_machine.system() == 'windows'
 		c_args += '-DOHMD_STATIC'
+		publish_c_args += '-DOHMD_STATIC'
 	endif
 endif
 
@@ -199,6 +202,7 @@ if _examples.contains('simple')
 	executable(
 		'openhmd_simple_example',
 		simple_sources,
+		c_args: publish_c_args,
 		include_directories: include_directories('./include'),
 		link_with: [openhmd_lib],
 		dependencies: deps,
@@ -222,6 +226,7 @@ if _examples.contains('opengl')
 	executable(
 		'openhmd_opengl_example',
 		opengl_sources,
+		c_args: publish_c_args,
 		include_directories: include_directories([
 			'./include',
 			'examples/opengl'
@@ -247,6 +252,7 @@ pkg.generate(
 	subdirs: 'openhmd',
 	requires: hidapi,
 	libraries: openhmd_lib,
+	extra_cflags: publish_c_args,
 	url: 'http://www.openhmd.net/',
 )
 install_headers('include/openhmd.h', subdir: 'openhmd')
@@ -254,6 +260,7 @@ install_headers('include/openhmd.h', subdir: 'openhmd')
 # Declare openhmd as a dependency so it can be used
 # as a meson subproject
 openhmd_dep = declare_dependency(
+  compile_args: publish_c_args,
   include_directories: include_directories('./include'),
   link_with : openhmd_lib)
 
@@ -274,6 +281,7 @@ if get_option('tests')
 	unittests = executable(
 		'openhmd_unittests',
 		unittests_sources,
+		c_args: publish_c_args,
 		include_directories: include_directories('./include', './src'),
 		link_with: [openhmd_lib],
 		dependencies: [dep_libm, dep_threads]


### PR DESCRIPTION
If the library was built for static linking, the project compiling
against it will need to specify -DOHMD_STATIC when including the
headers on Windows, or the declspec symbol declarations are
incorrect.

Export the right cflags in the pkgconfig and declared
dependency object so that happens.