### PR TITLE
Cmake installation path fixes based on system arch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/")
 
 option(BUILD_BOTH_STATIC_SHARED_LIBS OFF)
 
+include(GNUInstallDirs)
+
 #source files set just for Android
 set(openhmd_source_files
 	${CMAKE_CURRENT_LIST_DIR}/src/openhmd.c
@@ -248,7 +250,8 @@ CONFIGURE_FILE(
   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
 )
 
-install(TARGETS ${TARGETS} DESTINATION lib)
+install(TARGETS ${TARGETS} DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(FILES include/openhmd.h DESTINATION include)
 install(FILES "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc"
-        DESTINATION lib/pkgconfig)
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+

--- a/pkg-config/openhmd.pc.cmakein
+++ b/pkg-config/openhmd.pc.cmakein
@@ -1,6 +1,6 @@
-prefix=${CMAKE_INSTALL_PREFIX}
-libdir=$${PKG_CONFIG_INCLUDEDIR}
-includedir=${PKG_CONFIG_LIBDIR}
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include/openhmd
 
 Name: openhmd
 Description: API and drivers for immersive technology devices such as HMDs


### PR DESCRIPTION
Hello, I'm working on bring openHMD into Fedora space but when I try to install via cmake files list results are;

```
   /usr/include/openhmd.h
   /usr/lib/libopenhmd.so
   /usr/lib/libopenhmd.so.0
   /usr/lib/libopenhmd.so.0.1.0
   /usr/lib/pkgconfig/openhmd.pc

```
This fix change all of them into (based on arch) 

```
   /usr/include/openhmd.h
   /usr/lib64/libopenhmd.so
   /usr/lib64/libopenhmd.so.0
   /usr/lib64/libopenhmd.so.0.1.0
   /usr/lib64/pkgconfig/openhmd.pc
```

This should be also make easier for other distributions work on it. 