### PR TITLE
Changed the device class of nolo head tracker.

### DIFF
--- a/src/drv_nolo/nolo.c
+++ b/src/drv_nolo/nolo.c
@@ -378,7 +378,7 @@ static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
 			strcpy(desc->path, cur_dev->path);
 
 			desc->device_flags = OHMD_DEVICE_FLAGS_POSITIONAL_TRACKING | OHMD_DEVICE_FLAGS_ROTATIONAL_TRACKING;
-			desc->device_class = OHMD_DEVICE_CLASS_HMD;
+			desc->device_class = OHMD_DEVICE_CLASS_GENERIC_TRACKER;
 
 			desc->driver_ptr = driver;
 			desc->id = id++;


### PR DESCRIPTION
The device class for the nolo head tracker was set to an HMD.  This causes problems on dependant projects like Monado which expects HMDs to include display devices.

The nolo head tracker is not an HMD so this commit changes it to a generic tracker class.