### PR TITLE
Rudimentary support for the Pimax 4K

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ option(OPENHMD_DRIVER_HTC_VIVE "HTC Vive" ON)
 option(OPENHMD_DRIVER_NOLO "NOLO VR CV1" ON)
 option(OPENHMD_DRIVER_XGVR "3Glasses HMD" ON)
 option(OPENHMD_DRIVER_VRTEK "VR-Tek HMD" ON)
+option(OPENHMD_DRIVER_PIMAX "Pimax 4K" ON)
 option(OPENHMD_DRIVER_EXTERNAL "External sensor driver" ON)
 option(OPENHMD_DRIVER_ANDROID "General Android driver" OFF)
 
@@ -166,6 +167,18 @@ if(OPENHMD_DRIVER_VRTEK)
 	include_directories(${HIDAPI_INCLUDE_DIRS})
 	set(LIBS ${LIBS} ${HIDAPI_LIBRARIES})
 endif(OPENHMD_DRIVER_VRTEK)
+
+if(OPENHMD_DRIVER_PIMAX)
+    set(openhmd_source_files ${openhmd_source_files}
+    ${CMAKE_CURRENT_LIST_DIR}/src/drv_pimax/pimax.c
+    ${CMAKE_CURRENT_LIST_DIR}/src/drv_pimax/packet.c
+    )
+    add_definitions(-DDRIVER_PIMAX)
+
+    find_package(HIDAPI REQUIRED)
+    include_directories(${HIDAPI_INCLUDE_DIRS})
+    set(LIBS ${LIBS} ${HIDAPI_LIBRARIES})
+endif(OPENHMD_DRIVER_PIMAX)
 
 if (OPENHMD_DRIVER_EXTERNAL)
 	set(openhmd_source_files ${openhmd_source_files}

--- a/src/drv_pimax/packet.c
+++ b/src/drv_pimax/packet.c
@@ -1,0 +1,157 @@
+/*
+ * OpenHMD - Free and Open Source API and drivers for immersive technology.
+ * Copyright (C) 2013 Fredrik Hultin.
+ * Copyright (C) 2013 Jakob Bornecrantz.
+ * Distributed under the Boost 1.0 licence, see LICENSE for full text.
+ */
+
+/* New-Driver template Driver - Packet Decoding and Utilities */
+
+#include <stdio.h>
+#include "pimax.h"
+
+#define SKIP_CMD (buffer++)
+#define READ8 *(buffer++);
+#define READ16 *buffer | (*(buffer + 1) << 8); buffer += 2;
+#define READ32 *buffer | (*(buffer + 1) << 8) | (*(buffer + 2) << 16) | (*(buffer + 3) << 24); buffer += 4;
+#define READFLOAT ((float)(*buffer)); buffer += 4;
+#define READFIXED (float)(*buffer | (*(buffer + 1) << 8) | (*(buffer + 2) << 16) | (*(buffer + 3) << 24)) / 1000000.0f; buffer += 4;
+
+#define WRITE8(_val) *(buffer++) = (_val);
+#define WRITE16(_val) WRITE8((_val) & 0xff); WRITE8(((_val) >> 8) & 0xff);
+#define WRITE32(_val) WRITE16((_val) & 0xffff) *buffer; WRITE16(((_val) >> 16) & 0xffff);
+
+bool decodesensor_range(pkt_sensor_range* range, const unsigned char* buffer, int size)
+{
+    if(!(size == 8 || size == 9)){
+        LOGE("invalid packet size (expected 8 or 9 but got %d)", size);
+        return false;
+    }
+
+    SKIP_CMD;
+    range->command_id = READ16;
+    range->accel_scale = READ8;
+    range->gyro_scale = READ16;
+    range->mag_scale = READ16;
+
+    return true;
+}
+
+bool decodesensor_display_info(pkt_sensor_display_info* info, const unsigned char* buffer, int size)
+{
+    if(!(size == 56 || size == 57)){
+        LOGE("invalid packet size (expected 56 or 57 but got %d)", size);
+        //return false;
+    }
+
+    SKIP_CMD;
+    info->command_id = READ16;
+    info->distortion_type = READ8;
+    info->h_resolution = READ16;
+    info->v_resolution = READ16;
+    info->h_screen_size = READFIXED;
+    info->v_screen_size = READFIXED;
+    info->v_center = READFIXED;
+    info->lens_separation = READFIXED;
+    info->eye_to_screen_distance[0] = READFIXED;
+    info->eye_to_screen_distance[1] = READFIXED;
+
+    info->distortion_type_opts = 0;
+
+    for(int i = 0; i < 6; i++)
+        info->distortion_k[i] = READFLOAT;
+
+    return true;
+}
+
+//For use with packing
+static void decodesample(const unsigned char* buffer, int32_t* smp)
+{
+    /*
+     * Decode 3 tightly packed 21 bit values from 4 bytes.
+     * We unpack them in the higher 21 bit values first and then shift
+     * them down to the lower in order to get the sign bits correct.
+     */
+
+    int x = (buffer[0] << 24)          | (buffer[1] << 16) | ((buffer[2] & 0xF8) << 8);
+    int y = ((buffer[2] & 0x07) << 29) | (buffer[3] << 21) | (buffer[4] << 13) | ((buffer[5] & 0xC0) << 5);
+    int z = ((buffer[5] & 0x3F) << 26) | (buffer[6] << 18) | (buffer[7] << 10);
+
+    smp[0] = x >> 11;
+    smp[1] = y >> 11;
+    smp[2] = z >> 11;
+}
+
+bool pm_decode_tracker_sensor_msg(pkt_tracker_sensor* msg, const unsigned char* buffer, int size)
+{
+    if(!(size == 62 || size == 64)){
+        LOGE("invalid packet size (expected 62 or 64 but got %d)", size);
+        return false;
+    }
+
+    SKIP_CMD;
+    msg->last_command_id = READ16;
+    msg->num_samples = READ8;
+    /* Next is the number of samples since start, excluding the samples
+       contained in this packet */
+    buffer += 2;		// unused: nb_samples_since_start
+    msg->temperature = READ16;
+    msg->timestamp = READ32;
+    LOGI("timestamp %08X", msg->timestamp);
+    /* Second sample value is junk (outdated/uninitialized) value if
+       num_samples < 2. */
+    LOGI("samples %02X", msg->num_samples);
+    msg->num_samples = OHMD_MIN(msg->num_samples, 2);
+    for (int i = 0; i < msg->num_samples; i++) {
+        decodesample(buffer, msg->samples[i].accel);
+        buffer += 8;
+
+        decodesample(buffer, msg->samples[i].gyro);
+        buffer += 8;
+    }
+
+    // Skip empty samples
+    buffer += (2 - msg->num_samples) * 16;
+
+    for (int i = 0; i < 3; i++) {
+        msg->mag[i] = READ16;
+    }
+
+    return true;
+}
+
+//const static float SCALEFACTOR = 0.000061035156f;
+const static float SCALEFACTOR = 0.0001f;
+
+void vec3f_from_gryo(const int32_t* smp, vec3f* out_vec, const float* gyro_offset)
+{
+    out_vec->x = ((float)smp[0] * SCALEFACTOR) - gyro_offset[0];
+    out_vec->y = ((float)smp[1] * SCALEFACTOR) - gyro_offset[1];
+    out_vec->z = ((float)smp[2] * SCALEFACTOR) - gyro_offset[2];
+}
+
+void vec3f_from_accel(const int32_t* smp, vec3f* out_vec)
+{
+    out_vec->x = (float)smp[0] * SCALEFACTOR;
+    out_vec->y = (float)smp[1] * SCALEFACTOR;
+    out_vec->z = (float)smp[2] * SCALEFACTOR;
+}
+
+void vec3f_from_mag(const int32_t* smp, vec3f* out_vec)
+{
+    out_vec->x = (float)smp[0] * SCALEFACTOR;
+    out_vec->y = (float)smp[1] * SCALEFACTOR;
+    out_vec->z = (float)smp[2] * SCALEFACTOR;
+}
+
+void pm_dump_packet_tracker_sensor(const pkt_tracker_sensor* sensor)
+{
+    (void)sensor;
+    LOGI("  tick: 		%u", sensor->tick);
+    for(int i = 0; i < 2; i++){
+        LOGI("    accel: %d %d %d", sensor->samples[i].accel[0], sensor->samples[i].accel[1], sensor->samples[i].accel[2]);
+        LOGI("    gyro:  %d %d %d", sensor->samples[i].gyro[0], sensor->samples[i].gyro[1], sensor->samples[i].gyro[2]);
+        LOGI("    mag:  %d %d %d", sensor->mag[0], sensor->mag[1], sensor->mag[2]);
+    }
+}
+

--- a/src/drv_pimax/pimax.c
+++ b/src/drv_pimax/pimax.c
@@ -1,0 +1,309 @@
+/*
+ * OpenHMD - Free and Open Source API and drivers for immersive technology.
+ * Copyright (C) 2013 Fredrik Hultin.
+ * Copyright (C) 2013 Jakob Bornecrantz.
+ * Distributed under the Boost 1.0 licence, see LICENSE for full text.
+ */
+
+#include <stdlib.h>
+#include <hidapi.h>
+#include <string.h>
+#include <stdio.h>
+#include <time.h>
+#include <assert.h>
+
+#include "pimax.h"
+#include "../hid.h"
+
+#define OHMD_GRAVITY_EARTH 9.80665 // m/s²
+
+#define TICK_LEN (1.0f / 1000000.0f) // 1000 Hz ticks
+#define KEEP_ALIVE_VALUE (10 * 1000)
+#define SETFLAG(_s, _flag, _val) (_s) = ((_s) & ~(_flag)) | ((_val) ? (_flag) : 0)
+
+#define DEVICE_ID					0x0483
+#define DEVICE_HMD					0x0021
+
+typedef struct {
+    ohmd_device base;
+
+    hid_device* handle;
+    pkt_sensor_range sensor_range;
+    pkt_sensor_display_info display_info;
+    pkt_sensor_config sensor_config;
+    pkt_tracker_sensor sensor;
+    double last_keep_alive;
+    uint32_t last_imu_timestamp;
+    fusion sensor_fusion;
+    vec3f raw_mag, raw_accel, raw_gyro;
+} drv_priv;
+
+static drv_priv* drv_priv_get(ohmd_device* device)
+{
+    return (drv_priv*)device;
+}
+
+static int get_feature_report(drv_priv* priv, drv_sensor_feature_cmd cmd, unsigned char* buf)
+{
+    memset(buf, 0, FEATURE_BUFFER_SIZE);
+    buf[0] = (unsigned char)cmd;
+    return hid_get_feature_report(priv->handle, buf, FEATURE_BUFFER_SIZE);
+}
+
+static int send_feature_report(drv_priv* priv, const unsigned char *data, size_t length)
+{
+    return hid_send_feature_report(priv->handle, data, length);
+}
+
+static void handle_tracker_sensor_msg(drv_priv* priv, unsigned char* buffer, int size)
+{
+    uint32_t last_sample_tick = priv->sensor.tick;
+
+    if(!pm_decode_tracker_sensor_msg(&priv->sensor, buffer, size)){
+        LOGE("couldn't decode tracker sensor message");
+    }
+
+    pkt_tracker_sensor* s = &priv->sensor;
+
+    pm_dump_packet_tracker_sensor(s);
+
+    uint32_t tick_delta = 1000;
+    if(last_sample_tick > 0) //startup correction
+        tick_delta = s->tick - last_sample_tick;
+
+    // TODO: handle overflows in a nicer way
+    float dt = TICK_LEN;	// TODO: query the Rift for the sample rate
+    if (s->timestamp > priv->last_imu_timestamp) {
+        dt = (s->timestamp - priv->last_imu_timestamp) / 1000000.0f;
+        dt -= (s->num_samples - 1) * TICK_LEN;	// TODO: query the Pimax for the sample rate
+    }
+
+    // TODO: find a use for these values. got some of
+    //       these values whilst reverse engineering
+    //       but currently don't have a use for them.
+    const float accel_scale = OHMD_GRAVITY_EARTH / 4;
+    const float gyro_scale = 1.0 / 2000;
+    const float mag_scale = 1.0 / 49120;
+
+    int32_t mag32[] = { s->mag[0], s->mag[1], s->mag[2] };
+    vec3f_from_mag(mag32, &priv->raw_mag);
+
+    // TODO: put this somewhere nice and maybe configurable
+    //       these are the magic numbers from one manual calibration run
+    //       with the python scripts from OpenHmdPimaxTools
+    const float gyro_offset[] = { 0.0029455, -0.0009648000000000001, -0.002771 };
+
+    for(int i = 0; i < s->num_samples; i++){ // just use 1 sample since we don't have sample order for this frame
+        vec3f_from_accel(s->samples[i].accel, &priv->raw_accel);
+        vec3f_from_gryo(s->samples[i].gyro, &priv->raw_gyro, gyro_offset);
+
+        ofusion_update(&priv->sensor_fusion, dt, &priv->raw_gyro, &priv->raw_accel, &priv->raw_mag);
+
+        // reset dt to tick_len for the last samples if there were more than one sample
+        dt = TICK_LEN;	// TODO: query the Pimax for the sample rate
+    }
+
+    priv->last_imu_timestamp = s->timestamp;
+
+}
+
+#define WRITE8(_val) *(buffer++) = (_val);
+static int encode_pimax_cmd_17(unsigned char *buffer)
+{
+    WRITE8(0x11);
+    WRITE8(0x00);
+    WRITE8(0x00);
+    WRITE8(0x0b);
+    WRITE8(0x10);
+    WRITE8(0x27);
+    return 6;
+}
+
+
+static void update_device(ohmd_device* device)
+{
+    int size = 0;
+
+    drv_priv* priv = drv_priv_get(device);
+    unsigned char buffer[FEATURE_BUFFER_SIZE];
+
+    double t = ohmd_get_tick();
+    // Keep alive interval hardcoded to 3 sec
+    if (t - priv->last_keep_alive >= 3) {
+        int size = encode_pimax_cmd_17(buffer);
+        if (send_feature_report(priv, buffer, size) == -1) {
+            LOGE("error setting up cmd17");
+        } else {
+            LOGI("OK1");
+        }
+        priv->last_keep_alive = t;
+    }
+
+    while((size = hid_read(priv->handle, buffer, FEATURE_BUFFER_SIZE)) > 0) {
+        // currently the only message type the hardware supports (I think)
+        if(buffer[0] == 11){
+            handle_tracker_sensor_msg(priv, buffer, size);
+        }else{
+            LOGE("unknown message type: %u", buffer[0]);
+        }
+    }
+}
+
+static int getf(ohmd_device* device, ohmd_float_value type, float* out)
+{
+    drv_priv* priv = drv_priv_get(device);
+
+    switch(type){
+        case OHMD_DISTORTION_K: {
+                                    for (int i = 0; i < 6; i++) {
+                                        out[i] = priv->display_info.distortion_k[i];
+                                    }
+                                    break;
+                                }
+
+        case OHMD_ROTATION_QUAT: {
+                                     *(quatf*)out = priv->sensor_fusion.orient;
+                                     break;
+                                 }
+
+        case OHMD_POSITION_VECTOR:
+                                 out[0] = out[1] = out[2] = 0;
+                                 break;
+
+        default:
+                                 ohmd_set_error(priv->base.ctx, "invalid type given to getf (%ud)", type);
+                                 return -1;
+                                 break;
+    }
+
+    return 0;
+}
+
+static void close_device(ohmd_device* device)
+{
+    LOGD("closing device");
+    drv_priv* priv = drv_priv_get(device);
+    hid_close(priv->handle);
+    free(priv);
+}
+
+static ohmd_device* open_device(ohmd_driver* driver, ohmd_device_desc* desc)
+{
+    drv_priv* priv = ohmd_alloc(driver->ctx, sizeof(drv_priv));
+    if(!priv)
+        goto cleanup;
+
+    priv->base.ctx = driver->ctx;
+
+    // Open the HID device
+    priv->handle = hid_open_path(desc->path);
+
+    if(!priv->handle) {
+        char* path = _hid_to_unix_path(desc->path);
+        ohmd_set_error(driver->ctx, "Could not open %s. "
+                "Check your rights.", path);
+        free(path);
+        goto cleanup;
+    }
+
+    if(hid_set_nonblocking(priv->handle, 1) == -1){
+        ohmd_set_error(driver->ctx, "failed to set non-blocking on device");
+        goto cleanup;
+    }
+
+    unsigned char buf[FEATURE_BUFFER_SIZE];
+
+    int size;
+
+    // Update the time of the last keep alive we have sent.
+    priv->last_keep_alive = ohmd_get_tick();
+
+    // Set default device properties
+    ohmd_set_default_device_properties(&priv->base.properties);
+
+    // Set device properties
+    //NOTE: These values are estimations, no one has taken one appart to check
+    priv->base.properties.hsize = 0.1698f;
+    priv->base.properties.vsize = 0.0936f;
+    priv->base.properties.hres = 1920;
+    priv->base.properties.vres = 1080;
+    priv->base.properties.lens_sep = 0.0849f;
+    priv->base.properties.lens_vpos = 0.0468f;;
+    priv->base.properties.fov = DEG_TO_RAD(110.0); // TODO calculate.
+    priv->base.properties.ratio = ((float)1920 / (float)1080) / 2.0f;
+
+    // taken from the 3glasses, almost certainly not accurate
+    ohmd_set_universal_distortion_k(&(priv->base.properties), 0.75239515, -0.84751135, 0.42455423, 0.66200626);
+
+    // manually dialed in, may not be perfect
+    ohmd_set_universal_aberration_k(&(priv->base.properties), 0.995, 1.000, 1.005);
+
+    // calculate projection eye projection matrices from the device properties
+    ohmd_calc_default_proj_matrices(&priv->base.properties);
+
+    // set up device callbacks
+    priv->base.update = update_device;
+    priv->base.close = close_device;
+    priv->base.getf = getf;
+
+    // initialize sensor fusion
+    ofusion_init(&priv->sensor_fusion);
+
+    return &priv->base;
+
+cleanup:
+    if(priv)
+        free(priv);
+
+    return NULL;
+}
+
+static void get_device_list(ohmd_driver* driver, ohmd_device_list* list)
+{
+    struct hid_device_info* devs = hid_enumerate(DEVICE_ID, DEVICE_HMD);
+    struct hid_device_info* cur_dev = devs;
+
+    while (cur_dev) {
+        ohmd_device_desc* desc = &list->devices[list->num_devices++];
+
+        strcpy(desc->driver, "OpenHMD PIMAX Driver");
+        strcpy(desc->vendor, "PIMAX");
+        strcpy(desc->product, "PIMAX 4K");
+
+        desc->revision = 0;
+        desc->device_class = OHMD_DEVICE_CLASS_HMD;
+        desc->device_flags = OHMD_DEVICE_FLAGS_ROTATIONAL_TRACKING;
+
+        strcpy(desc->path, cur_dev->path);
+
+        desc->driver_ptr = driver;
+
+        cur_dev = cur_dev->next;
+    }
+
+    hid_free_enumeration(devs);
+}
+
+static void destroy_driver(ohmd_driver* drv)
+{
+    LOGD("shutting down driver");
+    hid_exit();
+    free(drv);
+}
+
+ohmd_driver* ohmd_create_pimax_drv(ohmd_context* ctx)
+{
+    ohmd_driver* drv = ohmd_alloc(ctx, sizeof(ohmd_driver));
+    if(drv == NULL)
+        return NULL;
+
+    drv->get_device_list = get_device_list;
+    drv->open_device = open_device;
+    drv->ctx = ctx;
+    drv->get_device_list = get_device_list;
+    drv->open_device = open_device;
+    drv->destroy = destroy_driver;
+
+    return drv;
+}
+

--- a/src/drv_pimax/pimax.h
+++ b/src/drv_pimax/pimax.h
@@ -1,0 +1,88 @@
+/*
+ * OpenHMD - Free and Open Source API and drivers for immersive technology.
+ * Copyright (C) 2013 Fredrik Hultin.
+ * Copyright (C) 2013 Jakob Bornecrantz.
+ * Distributed under the Boost 1.0 licence, see LICENSE for full text.
+ */
+
+/* New-Driver template Internal Interface */
+
+#ifndef PIMAX_H
+#define PIMAX_H
+
+#include "../openhmdi.h"
+
+#define FEATURE_BUFFER_SIZE 256
+
+typedef enum {
+    DRV_CMD_SENSOR_CONFIG = 2,
+    DRV_CMD_RANGE = 4,
+    DRV_CMD_KEEP_ALIVE = 8,
+    DRV_CMD_DISPLAY_INFO = 9
+} drv_sensor_feature_cmd;
+
+typedef struct {
+    uint16_t command_id;
+    uint16_t accel_scale;
+    uint16_t gyro_scale;
+    uint16_t mag_scale;
+} pkt_sensor_range;
+
+typedef struct {
+    int32_t accel[3];
+    int32_t gyro[3];
+} pkt_tracker_sample;
+
+typedef struct {
+    uint8_t num_samples;
+    uint32_t timestamp;
+    uint16_t last_command_id;
+    int16_t temperature;
+    uint32_t tick;
+    pkt_tracker_sample samples[3];
+    int16_t mag[3];
+} pkt_tracker_sensor;
+
+typedef struct {
+    uint16_t command_id;
+    uint8_t flags;
+    uint16_t packet_interval;
+    uint16_t keep_alive_interval; // in ms
+} pkt_sensor_config;
+
+typedef struct {
+    uint16_t command_id;
+    short distortion_type;
+    uint8_t distortion_type_opts;
+    uint16_t h_resolution, v_resolution;
+    float h_screen_size, v_screen_size;
+    float v_center;
+    float lens_separation;
+    float eye_to_screen_distance[2];
+    float distortion_k[6];
+} pkt_sensor_display_info;
+
+typedef struct {
+    uint16_t command_id;
+    uint16_t keep_alive_interval;
+} pkt_keep_alive;
+
+//bool decode_sensor_range(pkt_sensor_range* range, const unsigned char* buffer, int size);
+//bool decode_sensor_display_info(pkt_sensor_display_info* info, const unsigned char* buffer, int size);
+//bool decode_sensor_config(pkt_sensor_config* config, const unsigned char* buffer, int size);
+bool pm_decode_tracker_sensor_msg(pkt_tracker_sensor* msg, const unsigned char* buffer, int size);
+
+void vec3f_from_gryo(const int32_t* smp, vec3f* out_vec, const float* gyro_offset);
+void vec3f_from_accel(const int32_t* smp, vec3f* out_vec);
+void vec3f_from_mag(const int32_t* smp, vec3f* out_vec);
+
+//int encode_sensor_config(unsigned char* buffer, const pkt_sensor_config* config);
+//int encode_keep_alive(unsigned char* buffer, const pkt_keep_alive* keep_alive);
+
+//void dump_packet_sensor_range(const pkt_sensor_range* range);
+//void dump_packet_sensor_config(const pkt_sensor_config* config);
+//void dump_packet_sensor_display_info(const pkt_sensor_display_info* info);
+void pm_dump_packet_tracker_sensor(const pkt_tracker_sensor* sensor);
+
+#endif
+

--- a/src/openhmd.c
+++ b/src/openhmd.c
@@ -63,6 +63,10 @@ OHMD_APIENTRYDLL ohmd_context* OHMD_APIENTRY ohmd_ctx_create(void)
 	ctx->drivers[ctx->num_drivers++] = ohmd_create_vrtek_drv(ctx);
 #endif
 
+#if DRIVER_PIMAX
+	ctx->drivers[ctx->num_drivers++] = ohmd_create_pimax_drv(ctx);
+#endif
+
 #if DRIVER_ANDROID
 	ctx->drivers[ctx->num_drivers++] = ohmd_create_android_drv(ctx);
 #endif

--- a/src/openhmdi.h
+++ b/src/openhmdi.h
@@ -156,6 +156,7 @@ ohmd_driver* ohmd_create_psvr_drv(ohmd_context* ctx);
 ohmd_driver* ohmd_create_nolo_drv(ohmd_context* ctx);
 ohmd_driver* ohmd_create_xgvr_drv(ohmd_context* ctx);
 ohmd_driver* ohmd_create_vrtek_drv(ohmd_context* ctx);
+ohmd_driver* ohmd_create_pimax_drv(ohmd_context* ctx);
 ohmd_driver* ohmd_create_external_drv(ohmd_context* ctx);
 ohmd_driver* ohmd_create_android_drv(ohmd_context* ctx);
 


### PR DESCRIPTION
This commit merges with minimal cleanup and adjustments the branch "dev-pimax" by TheOnlyJoey. Raw USB/HID captures of a Pimax 4k were analyzed. The significant changes were that only HID responses of type "11" are relevant and can be triggered with HID request "17", and they run into a timeout after ~3 sec if no other "17" request is sent. The headset can still crash/stop sending data. Sometimes it resumes after a while. Otherwise, it needs to be replugged.

During testing, gyro drifting was noticed. So far, this was fixed with magic numbers gathered with external python scripts "grafdigital/OpenHmdPimaxTools" that may only work with the headset the data was pulled from. Should we look into setup functions or make these values configurable through files?

Lens correction needs improvement. This is the first draft to get passable graphical output. Head tracking is passable but lags a bit, but this could be due to the device.

Functionality was validated with "openglexample".

Still missing is the utilisation of magnetometer data.