### PR TITLE
Fixed build for building with just the Rift drivers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -72,17 +72,18 @@ else
 endif
 
 _drivers = get_option('drivers')
+
 if _drivers.contains('rift')
 	sources += [
 		'src/drv_oculus_rift/rift.c',
 		'src/drv_oculus_rift/rift-hmd-radio.c',
 		'src/drv_oculus_rift/packet.c',
+		'src/ext_deps/nxjson.c',
 	]
 	c_args += '-DDRIVER_OCULUS_RIFT'
 	deps += dep_hidapi
 endif
 
-_drivers = get_option('drivers')
 if _drivers.contains('rift-s')
 	sources += [
 		'src/drv_oculus_rift_s/rift-s.c',


### PR DESCRIPTION
I wanted to build the project using only the Oculus Rift (CV1) drivers. Unfortunately, this did not work, since the `src/ext_deps/nxjson.c` file was wrongfully not included in the build sources of the Meson build file.
This pull request fixes that build issue and removes another redundant line from the `meson.build` file, which was likely added due to a copy and paste mistake.